### PR TITLE
Remove leftover Vite template styles from App.css

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,4 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
-}
+/* TipStream global styles */
+/* All component styling is handled through Tailwind CSS utility classes. */
+/* This file is reserved for any global overrides that cannot be expressed */
+/* as Tailwind utilities. Keep it minimal. */


### PR DESCRIPTION
Cleared out the default Vite/React scaffold CSS that was sitting in App.css. These styles were never used by TipStream and the #root max-width constraint conflicted with the Tailwind-based layout.

closes #11