### PR TITLE
Update page title and add social meta tags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="TipStream - Send micro-tips to your favorite creators on the Stacks blockchain. Secured by Bitcoin, built with transparency." />
     <meta name="theme-color" content="#0f172a" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="TipStream - Micro-Tipping on Stacks" />
+    <meta property="og:description" content="Send micro-tips to your favorite creators on the Stacks blockchain. Secured by Bitcoin, built with transparency." />
+    <meta property="og:url" content="https://tipstream.app" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="TipStream - Micro-Tipping on Stacks" />
+    <meta name="twitter:description" content="Send micro-tips to your favorite creators on the Stacks blockchain." />
+
     <title>TipStream - Micro-Tipping on Stacks</title>
   </head>
   <body>


### PR DESCRIPTION
Changed the HTML title from the default 'frontend' to 'TipStream - Micro-Tipping on Stacks'. Added description, theme-color, Open Graph, and Twitter Card meta tags so link previews work on social media.

closes #12