### PR TITLE
Fill in Clarinet.toml project metadata

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -8,6 +8,8 @@ requirements = []
 
 [contracts.tipstream]
 path = "contracts/tipstream.clar"
+clarity_version = 2
+epoch = 3.0
 
 [repl]
 costs_version = 3


### PR DESCRIPTION
Add project description and author, remove leftover commented-out counter contract, and explicitly set clarity_version and epoch for the tipstream contract.

closes #65