### PR TITLE
Show fee breakdown in SendTip before submission

### DIFF
--- a/frontend/src/components/SendTip.jsx
+++ b/frontend/src/components/SendTip.jsx
@@ -134,6 +134,36 @@ export default function SendTip() {
                     </div>
                 </div>
 
+                {amount && parseFloat(amount) > 0 && (
+                    <div className="bg-gray-50 rounded-lg p-4 border border-gray-200 text-sm">
+                        <p className="font-semibold text-gray-700 mb-2">Transaction Breakdown</p>
+                        <div className="space-y-1 text-gray-600">
+                            <div className="flex justify-between">
+                                <span>Tip amount</span>
+                                <span>{parseFloat(amount).toFixed(6)} STX</span>
+                            </div>
+                            <div className="flex justify-between">
+                                <span>Platform fee (0.5%)</span>
+                                <span>
+                                    {formatSTX(
+                                        Math.floor(toMicroSTX(amount) * FEE_BASIS_POINTS / BASIS_POINTS_DIVISOR),
+                                        6
+                                    )} STX
+                                </span>
+                            </div>
+                            <div className="border-t border-gray-200 pt-1 mt-1 flex justify-between font-semibold text-gray-800">
+                                <span>Recipient receives</span>
+                                <span>
+                                    {formatSTX(
+                                        toMicroSTX(amount) - Math.floor(toMicroSTX(amount) * FEE_BASIS_POINTS / BASIS_POINTS_DIVISOR),
+                                        6
+                                    )} STX
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                )}
+
                 <button
                     onClick={handleSendTip}
                     disabled={loading}


### PR DESCRIPTION
Display a live transaction breakdown showing the tip amount, the 0.5% platform fee, and the net amount reaching the recipient. Uses the same basis-point math as the on-chain contract so users know exactly what they are signing.

closes #46