### PR TITLE
Wire Learn More button to project README

### DIFF
--- a/frontend/src/components/ui/animated-hero.jsx
+++ b/frontend/src/components/ui/animated-hero.jsx
@@ -76,7 +76,12 @@ function AnimatedHero({ onGetStarted }) {
                         >
                             Get Started Now <Zap className="w-4 h-4" />
                         </Button>
-                        <Button size="lg" className="gap-4" variant="outline">
+                        <Button
+                            size="lg"
+                            className="gap-4"
+                            variant="outline"
+                            onClick={() => window.open('https://github.com/Mosas2000/TipStream#readme', '_blank', 'noopener')}
+                        >
                             Learn More <MoveRight className="w-4 h-4" />
                         </Button>
                     </div>


### PR DESCRIPTION
The Learn More button in the hero section had no click handler or destination. Link it to the project README on GitHub.

closes #55