### PR TITLE
Show feedback when wallet transaction is cancelled

### DIFF
--- a/frontend/src/components/SendTip.jsx
+++ b/frontend/src/components/SendTip.jsx
@@ -78,6 +78,7 @@ export default function SendTip({ addToast }) {
                     addToast('Tip sent successfully! Transaction: ' + data.txId, 'success');
                 },
                 onCancel: () => {
+                    console.info('Transaction cancelled by user');
                     setLoading(false);
                     addToast('Transaction cancelled. Your funds were not transferred.', 'info');
                 }


### PR DESCRIPTION
The onCancel callback now shows an info toast telling the user their transaction was cancelled and no funds were transferred. Also adds a console log for debugging.

closes #103