### PR TITLE
enforce minimum fee of 1 uSTX to prevent truncation to zero

### DIFF
--- a/contracts/tipstream.clar
+++ b/contracts/tipstream.clar
@@ -14,6 +14,7 @@
 
 (define-constant basis-points-divisor u10000)
 (define-constant min-tip-amount u1000)
+(define-constant min-fee u1)
 
 ;; Data Variables
 (define-data-var total-tips-sent uint u0)
@@ -52,7 +53,15 @@
 
 ;; Private Functions
 (define-private (calculate-fee (amount uint))
-    (/ (* amount (var-get current-fee-basis-points)) basis-points-divisor)
+    (let
+        (
+            (raw-fee (/ (* amount (var-get current-fee-basis-points)) basis-points-divisor))
+        )
+        (if (> (var-get current-fee-basis-points) u0)
+            (if (< raw-fee min-fee) min-fee raw-fee)
+            u0
+        )
+    )
 )
 
 (define-private (send-tip-tuple (tip-data { recipient: principal, amount: uint, message: (string-utf8 280) }))

--- a/tests/tipstream.test.ts
+++ b/tests/tipstream.test.ts
@@ -106,6 +106,21 @@ describe("TipStream Contract Tests", () => {
         expect(result).toBeOk(Cl.uint(5000));
     });
 
+    it("enforces minimum fee of 1 uSTX when raw calculation truncates to zero", () => {
+        simnet.callPublicFn("tipstream", "set-fee-basis-points", [Cl.uint(1)], deployer);
+
+        const { result } = simnet.callReadOnlyFn(
+            "tipstream",
+            "get-fee-for-amount",
+            [Cl.uint(1000)],
+            wallet1
+        );
+
+        expect(result).toBeOk(Cl.uint(1));
+
+        simnet.callPublicFn("tipstream", "set-fee-basis-points", [Cl.uint(50)], deployer);
+    });
+
     it("platform stats track correctly", () => {
         simnet.callPublicFn(
             "tipstream",


### PR DESCRIPTION
Integer division in calculate-fee can truncate small fee amounts to zero. This change ensures the platform always collects at least 1 uSTX when the fee rate is non-zero, while still allowing a 0 fee when the admin explicitly sets the rate to 0 basis points.

- Wrap calculate-fee with a conditional minimum check
- Add min-fee constant (u1)
- Add test verifying the minimum fee triggers with 1bp rate and 1000 uSTX amount

Closes #18