### PR TITLE
add print events to all public functions for off-chain indexing

### DIFF
--- a/tests/tipstream.test.ts
+++ b/tests/tipstream.test.ts
@@ -20,7 +20,7 @@ describe("TipStream Contract Tests", () => {
         );
 
         expect(result).toBeOk(Cl.uint(0));
-        expect(events).toHaveLength(2);
+        expect(events).toHaveLength(3);
     });
 
     it("cannot send tip to self", () => {


### PR DESCRIPTION
Emit structured print events from all public functions to enable Chainhook and other indexing tools to efficiently track contract activity.

Events added:
- `tip-sent`: tip-id, sender, recipient, amount, fee, net-amount
- `profile-updated`: user, display-name
- `user-blocked`: blocker, blocked, is-blocked
- `contract-paused`: paused
- `fee-updated`: new-fee

Closes #19