### PR TITLE
Add two-step ownership transfer mechanism

### DIFF
--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -58,6 +58,7 @@ genesis:
     - pox-4
     - signers
     - signers-voting
+    - costs-4
 plan:
   batches:
     - id: 0


### PR DESCRIPTION
Convert contract-owner from constant to data variable to support ownership transfers. Implement propose-new-owner and accept-ownership functions with a two-step process for safe ownership handoff.

Changes:
- Convert contract-owner from define-constant to define-data-var
- Add pending-owner data variable for two-step transfer
- Add propose-new-owner function (owner-only)
- Add accept-ownership function (pending-owner-only)
- Add get-contract-owner and get-pending-owner read-only functions
- Add print events for ownership-proposed and ownership-transferred
- Add 4 tests covering the full ownership transfer flow

All 20 tests pass.

Closes #21