### PR TITLE
Add strict batch tipping with atomic error handling

### DIFF
--- a/contracts/tipstream.clar
+++ b/contracts/tipstream.clar
@@ -219,6 +219,23 @@
     (ok (map send-tip-tuple tips-list))
 )
 
+(define-private (strict-tip-fold
+    (tip-data { recipient: principal, amount: uint, message: (string-utf8 280) })
+    (acc (response uint uint))
+)
+    (match acc
+        ok-val (match (send-tip (get recipient tip-data) (get amount tip-data) (get message tip-data))
+            success (ok (+ ok-val u1))
+            error (err error)
+        )
+        err-val (err err-val)
+    )
+)
+
+(define-public (send-batch-tips-strict (tips-list (list 50 { recipient: principal, amount: uint, message: (string-utf8 280) })))
+    (fold strict-tip-fold tips-list (ok u0))
+)
+
 ;; Read-only Functions
 (define-read-only (get-tip (tip-id uint))
     (map-get? tips { tip-id: tip-id })


### PR DESCRIPTION
Add send-batch-tips-strict function that uses fold to abort the entire batch if any single tip fails, providing atomic batch execution.

The existing send-batch-tips continues to work with partial failures using map, giving users a choice between partial and atomic behavior.

Changes:
- Add strict-tip-fold private helper function
- Add send-batch-tips-strict public function
- Add 2 tests for strict batch success and failure rollback

All 22 tests pass.

Closes #22