### PR TITLE
Add get-multiple-user-stats read-only function for batch queries

### DIFF
--- a/contracts/tipstream.clar
+++ b/contracts/tipstream.clar
@@ -289,3 +289,7 @@
 (define-read-only (get-fee-for-amount (amount uint))
     (ok (calculate-fee amount))
 )
+
+(define-read-only (get-multiple-user-stats (users (list 20 principal)))
+    (ok (map get-user-stats users))
+)

--- a/tests/tipstream.test.ts
+++ b/tests/tipstream.test.ts
@@ -501,4 +501,37 @@ describe("TipStream Contract Tests", () => {
             expect(pending).toBeOk(Cl.none());
         });
     });
+
+    describe("multi-user stats", () => {
+        it("returns stats for multiple users in a single call", () => {
+            simnet.callPublicFn(
+                "tipstream",
+                "send-tip",
+                [Cl.principal(wallet2), Cl.uint(1000000), Cl.stringUtf8("test")],
+                wallet1
+            );
+
+            const { result } = simnet.callReadOnlyFn(
+                "tipstream",
+                "get-multiple-user-stats",
+                [Cl.list([Cl.principal(wallet1), Cl.principal(wallet2)])],
+                deployer
+            );
+
+            expect(result).toBeOk(Cl.list([
+                Cl.tuple({
+                    "tips-sent": Cl.uint(1),
+                    "tips-received": Cl.uint(0),
+                    "total-sent": Cl.uint(1000000),
+                    "total-received": Cl.uint(0)
+                }),
+                Cl.tuple({
+                    "tips-sent": Cl.uint(0),
+                    "tips-received": Cl.uint(1),
+                    "total-sent": Cl.uint(0),
+                    "total-received": Cl.uint(1000000)
+                })
+            ]));
+        });
+    });
 });


### PR DESCRIPTION
Add read-only function that accepts a list of up to 20 principals and returns their stats in a single call, enabling efficient leaderboard data fetching.

Closes #28