### PR TITLE
Add auto-refresh and manual refresh to data components

### DIFF
--- a/frontend/src/components/PlatformStats.jsx
+++ b/frontend/src/components/PlatformStats.jsx
@@ -10,6 +10,7 @@ export default function PlatformStats() {
     const [stats, setStats] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [lastRefresh, setLastRefresh] = useState(null);
 
     const fetchPlatformStats = useCallback(async () => {
         try {
@@ -25,6 +26,7 @@ export default function PlatformStats() {
             const jsonResult = cvToJSON(result);
             setStats(jsonResult.value);
             setLoading(false);
+            setLastRefresh(new Date());
         } catch (error) {
             console.error('Failed to fetch platform stats:', error.message || error);
             setError('Unable to load platform statistics. Please try again later.');
@@ -35,6 +37,11 @@ export default function PlatformStats() {
     useEffect(() => {
         fetchPlatformStats();
     }, [fetchPlatformStats, refreshCounter]);
+
+    useEffect(() => {
+        const interval = setInterval(fetchPlatformStats, 60000);
+        return () => clearInterval(interval);
+    }, [fetchPlatformStats]);
 
     if (loading) {
         return (
@@ -64,9 +71,22 @@ export default function PlatformStats() {
         <div className="bg-white p-8 rounded-[2.5rem] shadow-sm border border-gray-100">
             <div className="flex items-center justify-between mb-10">
                 <h2 className="text-3xl font-black text-slate-900 tracking-tight">Global Impact</h2>
-                <div className="bg-green-100 text-green-700 px-4 py-1.5 rounded-full text-xs font-bold uppercase tracking-widest flex items-center">
-                    <span className="h-2 w-2 bg-green-500 rounded-full mr-2 animate-pulse"></span>
-                    Live Network
+                <div className="flex items-center gap-3">
+                    {lastRefresh && (
+                        <span className="text-xs text-gray-400">
+                            Updated {lastRefresh.toLocaleTimeString()}
+                        </span>
+                    )}
+                    <button
+                        onClick={fetchPlatformStats}
+                        className="px-4 py-2 text-sm font-medium bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-xl transition-colors"
+                    >
+                        Refresh
+                    </button>
+                    <div className="bg-green-100 text-green-700 px-4 py-1.5 rounded-full text-xs font-bold uppercase tracking-widest flex items-center">
+                        <span className="h-2 w-2 bg-green-500 rounded-full mr-2 animate-pulse"></span>
+                        Live
+                    </div>
                 </div>
             </div>
 

--- a/frontend/src/components/RecentTips.jsx
+++ b/frontend/src/components/RecentTips.jsx
@@ -18,6 +18,7 @@ export default function RecentTips({ addToast }) {
     const [tipBackAmount, setTipBackAmount] = useState('0.5');
     const [tipBackMessage, setTipBackMessage] = useState('');
     const [sending, setSending] = useState(false);
+    const [lastRefresh, setLastRefresh] = useState(null);
 
     const fetchRecentTips = useCallback(async () => {
         try {
@@ -42,6 +43,7 @@ export default function RecentTips({ addToast }) {
 
             setTips(tipEvents);
             setLoading(false);
+            setLastRefresh(new Date());
         } catch (err) {
             console.error('Failed to fetch recent tips:', err.message || err);
             setError(err.message || 'Failed to load tips');
@@ -52,6 +54,11 @@ export default function RecentTips({ addToast }) {
     useEffect(() => {
         fetchRecentTips();
     }, [fetchRecentTips, refreshCounter]);
+
+    useEffect(() => {
+        const interval = setInterval(fetchRecentTips, 60000);
+        return () => clearInterval(interval);
+    }, [fetchRecentTips]);
 
     const parseTipEvent = (repr) => {
         try {
@@ -155,7 +162,22 @@ export default function RecentTips({ addToast }) {
 
     return (
         <div className="bg-white p-8 rounded-[2.5rem] shadow-sm border border-gray-100">
-            <h2 className="text-3xl font-black text-slate-900 tracking-tight mb-8">Live Feed</h2>
+            <div className="flex items-center justify-between mb-8">
+                <h2 className="text-3xl font-black text-slate-900 tracking-tight">Live Feed</h2>
+                <div className="flex items-center gap-3">
+                    {lastRefresh && (
+                        <span className="text-xs text-gray-400">
+                            Updated {lastRefresh.toLocaleTimeString()}
+                        </span>
+                    )}
+                    <button
+                        onClick={fetchRecentTips}
+                        className="px-4 py-2 text-sm font-medium bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-xl transition-colors"
+                    >
+                        Refresh
+                    </button>
+                </div>
+            </div>
 
             {tips.length === 0 ? (
                 <div className="text-center py-20 bg-slate-50 rounded-3xl border-2 border-dashed border-slate-200">

--- a/frontend/src/components/TipHistory.jsx
+++ b/frontend/src/components/TipHistory.jsx
@@ -14,6 +14,7 @@ export default function TipHistory({ userAddress }) {
     const [tips, setTips] = useState([]);
     const [loading, setLoading] = useState(true);
     const [tab, setTab] = useState('all');
+    const [lastRefresh, setLastRefresh] = useState(null);
 
     const fetchData = useCallback(async () => {
         if (!userAddress) return;
@@ -47,6 +48,7 @@ export default function TipHistory({ userAddress }) {
 
             setTips(userTips);
             setLoading(false);
+            setLastRefresh(new Date());
         } catch (error) {
             console.error('Failed to fetch tip history:', error.message || error);
             setLoading(false);
@@ -56,6 +58,11 @@ export default function TipHistory({ userAddress }) {
     useEffect(() => {
         fetchData();
     }, [fetchData, refreshCounter]);
+
+    useEffect(() => {
+        const interval = setInterval(fetchData, 60000);
+        return () => clearInterval(interval);
+    }, [fetchData]);
 
     const parseTipEvent = (repr) => {
         try {
@@ -108,7 +115,22 @@ export default function TipHistory({ userAddress }) {
 
     return (
         <div className="max-w-4xl mx-auto p-6">
-            <h2 className="text-2xl font-bold mb-8 text-gray-800">Your Activity</h2>
+            <div className="flex items-center justify-between mb-8">
+                <h2 className="text-2xl font-bold text-gray-800">Your Activity</h2>
+                <div className="flex items-center gap-3">
+                    {lastRefresh && (
+                        <span className="text-xs text-gray-400">
+                            Updated {lastRefresh.toLocaleTimeString()}
+                        </span>
+                    )}
+                    <button
+                        onClick={fetchData}
+                        className="px-4 py-2 text-sm font-medium bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-xl transition-colors"
+                    >
+                        Refresh
+                    </button>
+                </div>
+            </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-8">
                 <div className="bg-white p-8 rounded-2xl shadow-sm border border-gray-100 hover:shadow-md transition-shadow">


### PR DESCRIPTION
Implement 60-second auto-refresh polling and manual Refresh button with last-updated timestamp on RecentTips, PlatformStats, and TipHistory.

Closes #38