### PR TITLE
Add edge case tests for maximum fee limit

### DIFF
--- a/tests/tipstream.test.ts
+++ b/tests/tipstream.test.ts
@@ -336,6 +336,62 @@ describe("TipStream Contract Tests", () => {
 
             expect(result).toBeOk(Cl.uint(20000));
         });
+
+        it("accepts fee at exactly the maximum limit of 1000 basis points", () => {
+            const { result } = simnet.callPublicFn(
+                "tipstream",
+                "set-fee-basis-points",
+                [Cl.uint(1000)],
+                deployer
+            );
+            expect(result).toBeOk(Cl.bool(true));
+
+            const { result: fee } = simnet.callReadOnlyFn(
+                "tipstream",
+                "get-fee-for-amount",
+                [Cl.uint(1000000)],
+                wallet1
+            );
+            expect(fee).toBeOk(Cl.uint(100000));
+        });
+
+        it("rejects fee above the maximum limit of 1000 basis points", () => {
+            const { result } = simnet.callPublicFn(
+                "tipstream",
+                "set-fee-basis-points",
+                [Cl.uint(1001)],
+                deployer
+            );
+            expect(result).toBeErr(Cl.uint(101));
+        });
+
+        it("accepts zero fee to disable platform fees", () => {
+            const { result } = simnet.callPublicFn(
+                "tipstream",
+                "set-fee-basis-points",
+                [Cl.uint(0)],
+                deployer
+            );
+            expect(result).toBeOk(Cl.bool(true));
+
+            const { result: fee } = simnet.callReadOnlyFn(
+                "tipstream",
+                "get-fee-for-amount",
+                [Cl.uint(1000000)],
+                wallet1
+            );
+            expect(fee).toBeOk(Cl.uint(0));
+        });
+
+        it("non-owner cannot change fee", () => {
+            const { result } = simnet.callPublicFn(
+                "tipstream",
+                "set-fee-basis-points",
+                [Cl.uint(100)],
+                wallet1
+            );
+            expect(result).toBeErr(Cl.uint(100));
+        });
     });
 
     describe("Batch Tipping", () => {


### PR DESCRIPTION
## Summary

Add missing boundary condition tests for the `set-fee-basis-points` function.

## Tests Added

- **Exact max (1000 basis points)**: Confirms 10% fee cap is accepted and calculates correctly
- **Above max (1001 basis points)**: Verifies rejection with error u101
- **Zero fee**: Confirms fee can be set to 0 to disable platform fees
- **Non-owner rejection**: Verifies non-owners cannot modify fees

All 33 tests pass.

Closes #70