### PR TITLE
fix: API error handling with user-facing messages and retry

### DIFF
--- a/frontend/src/components/PlatformStats.jsx
+++ b/frontend/src/components/PlatformStats.jsx
@@ -29,7 +29,12 @@ export default function PlatformStats() {
             setLastRefresh(new Date());
         } catch (error) {
             console.error('Failed to fetch platform stats:', error.message || error);
-            setError('Unable to load platform statistics. Please try again later.');
+            const isNetworkError = error.message?.includes('fetch') || error.message?.includes('network') || error.name === 'TypeError';
+            setError(
+                isNetworkError
+                    ? 'Unable to reach the Stacks API. Check your connection and try again.'
+                    : `Failed to load platform statistics: ${error.message || 'Unknown error'}`
+            );
             setLoading(false);
         }
     }, []);

--- a/frontend/src/components/RecentTips.jsx
+++ b/frontend/src/components/RecentTips.jsx
@@ -55,7 +55,12 @@ export default function RecentTips({ addToast }) {
             setLastRefresh(new Date());
         } catch (err) {
             console.error('Failed to fetch recent tips:', err.message || err);
-            setError(err.message || 'Failed to load tips');
+            const isNetworkError = err.message?.includes('fetch') || err.message?.includes('network') || err.name === 'TypeError';
+            setError(
+                isNetworkError
+                    ? 'Unable to reach the Stacks API. Check your connection and try again.'
+                    : `Failed to load tips: ${err.message || 'Unknown error'}`
+            );
             setLoading(false);
         }
     }, []);


### PR DESCRIPTION
Closes #80

## Changes

- **TipHistory**: Add `error` state, show clear error message with retry button when Stacks API fetch fails. Validate API response status before parsing JSON.
- **PlatformStats**: Improve error messaging to differentiate network errors (API unreachable) from contract call failures.
- **RecentTips**: Improve error messaging with same network/contract error differentiation.

All three data-fetching components now:
1. Show user-friendly error messages instead of infinite spinners or empty states
2. Differentiate network errors from API response errors
3. Provide a retry button for quick recovery
4. Clear error state before retrying