### PR TITLE
fix: add CSP and security headers for frontend deployment

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,0 +1,6 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.hiro.so https://api.mainnet.hiro.so https://api.testnet.hiro.so https://api.coingecko.com https://stacks-node-api.mainnet.stacks.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'


### PR DESCRIPTION
Closes #85

## Changes

Add Netlify `_headers` file with comprehensive security headers:

- **Content-Security-Policy**: Restricts script, style, image, font, and connection sources. Allows Stacks API endpoints (Hiro mainnet/testnet) and CoinGecko for price feeds. Blocks framing and restricts form actions.
- **X-Frame-Options**: DENY - prevents clickjacking attacks
- **X-Content-Type-Options**: nosniff - prevents MIME type sniffing
- **Referrer-Policy**: strict-origin-when-cross-origin
- **Permissions-Policy**: Disables camera, microphone, and geolocation APIs

These headers protect the financial application from XSS, clickjacking, and data injection attacks.