### PR TITLE
feat: Add demo/sandbox mode for risk-free platform exploration (#98)

### DIFF
--- a/frontend/src/components/DemoBanner.jsx
+++ b/frontend/src/components/DemoBanner.jsx
@@ -1,0 +1,24 @@
+import { useDemoMode } from '../context/DemoContext';
+
+export default function DemoBanner() {
+  const { isDemo, exitDemo } = useDemoMode();
+
+  if (!isDemo) return null;
+
+  return (
+    <div className="bg-amber-500 text-amber-950 text-center py-2 px-4 text-sm font-semibold flex items-center justify-center gap-3 z-50 relative">
+      <span className="inline-flex items-center gap-1.5">
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        Demo Mode — No real STX is being used. Transactions are simulated.
+      </span>
+      <button
+        onClick={exitDemo}
+        className="ml-2 px-3 py-0.5 bg-amber-950 text-amber-100 rounded-full text-xs font-bold hover:bg-amber-900 transition-colors"
+      >
+        Exit Demo
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -4,7 +4,7 @@ import NotificationBell from './NotificationBell';
 import { useTheme } from '../context/ThemeContext';
 import { NETWORK_NAME, STACKS_API_BASE } from '../config/contracts';
 
-export default function Header({ userData, onAuth, authLoading, notifications, unreadCount, onMarkNotificationsRead, notificationsLoading }) {
+export default function Header({ userData, onAuth, authLoading, notifications, unreadCount, onMarkNotificationsRead, notificationsLoading, isDemo }) {
     const { theme, toggleTheme } = useTheme();
     const [apiReachable, setApiReachable] = useState(null);
 
@@ -74,6 +74,15 @@ export default function Header({ userData, onAuth, authLoading, notifications, u
                             />
                         )}
 
+                        {isDemo && !userData && (
+                            <div className="hidden sm:flex flex-col items-end">
+                                <span className="text-[10px] font-bold text-amber-400 uppercase tracking-tighter">Demo Wallet</span>
+                                <p className="text-xs font-mono text-white/90 bg-amber-500/20 px-2 py-1 rounded-lg border border-amber-500/30 truncate max-w-[140px] sm:max-w-none">
+                                    SP1DEMO...SANDBOX
+                                </p>
+                            </div>
+                        )}
+
                         {userData && (
                             <div className="hidden sm:flex flex-col items-end">
                                 <span className="text-[10px] font-bold text-gray-300 uppercase tracking-tighter">Connected Wallet</span>
@@ -95,7 +104,7 @@ export default function Header({ userData, onAuth, authLoading, notifications, u
                                 : 'bg-white text-gray-900 hover:bg-gray-50 hover:shadow-white/10'
                                 }`}
                         >
-                            {authLoading ? 'Connecting...' : userData ? 'Disconnect' : 'Connect Wallet'}
+                            {authLoading ? 'Connecting...' : userData ? 'Disconnect' : isDemo ? 'Connect Real Wallet' : 'Connect Wallet'}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/components/Leaderboard.jsx
+++ b/frontend/src/components/Leaderboard.jsx
@@ -1,17 +1,30 @@
 import { useEffect, useState, useCallback } from 'react';
 import { CONTRACT_ADDRESS, CONTRACT_NAME } from '../config/contracts';
 import { formatSTX, formatAddress } from '../lib/utils';
+import { useDemoMode } from '../context/DemoContext';
 import CopyButton from './ui/copy-button';
 
 const API_BASE = 'https://api.hiro.so';
 
 export default function Leaderboard() {
+    const { isDemo, demoLeaderboard } = useDemoMode();
     const [leaders, setLeaders] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [tab, setTab] = useState('sent');
 
     const fetchLeaderboard = useCallback(async () => {
+        if (isDemo) {
+            setLeaders(demoLeaderboard.map(l => ({
+                address: l.address,
+                totalSent: l.totalSent,
+                tipsSent: l.tipCount,
+                totalReceived: Math.floor(l.totalSent * 0.7),
+                tipsReceived: Math.floor(l.tipCount * 0.6),
+            })));
+            setLoading(false);
+            return;
+        }
         try {
             setLoading(true);
             setError(null);

--- a/frontend/src/components/PlatformStats.jsx
+++ b/frontend/src/components/PlatformStats.jsx
@@ -4,15 +4,23 @@ import { network } from '../utils/stacks';
 import { CONTRACT_ADDRESS, CONTRACT_NAME } from '../config/contracts';
 import { formatSTX } from '../lib/utils';
 import { useTipContext } from '../context/TipContext';
+import { useDemoMode } from '../context/DemoContext';
 
 export default function PlatformStats() {
     const { refreshCounter } = useTipContext();
+    const { isDemo, demoPlatformStats } = useDemoMode();
     const [stats, setStats] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [lastRefresh, setLastRefresh] = useState(null);
 
     const fetchPlatformStats = useCallback(async () => {
+        if (isDemo) {
+            setStats(demoPlatformStats);
+            setLoading(false);
+            setLastRefresh(new Date());
+            return;
+        }
         try {
             const result = await fetchCallReadOnlyFunction({
                 network,
@@ -88,9 +96,9 @@ export default function PlatformStats() {
                     >
                         Refresh
                     </button>
-                    <div className="bg-green-100 text-green-700 px-4 py-1.5 rounded-full text-xs font-bold uppercase tracking-widest flex items-center">
-                        <span className="h-2 w-2 bg-green-500 rounded-full mr-2 animate-pulse"></span>
-                        Live
+                    <div className={`${isDemo ? 'bg-amber-100 text-amber-700' : 'bg-green-100 text-green-700'} px-4 py-1.5 rounded-full text-xs font-bold uppercase tracking-widest flex items-center`}>
+                        <span className={`h-2 w-2 ${isDemo ? 'bg-amber-500' : 'bg-green-500'} rounded-full mr-2 animate-pulse`}></span>
+                        {isDemo ? 'Demo' : 'Live'}
                     </div>
                 </div>
             </div>

--- a/frontend/src/components/RecentTips.jsx
+++ b/frontend/src/components/RecentTips.jsx
@@ -5,6 +5,7 @@ import { CONTRACT_ADDRESS, CONTRACT_NAME } from '../config/contracts';
 import { formatSTX, toMicroSTX, formatAddress } from '../lib/utils';
 import { network, appDetails, userSession } from '../utils/stacks';
 import { useTipContext } from '../context/TipContext';
+import { useDemoMode } from '../context/DemoContext';
 import CopyButton from './ui/copy-button';
 
 const API_BASE = 'https://api.hiro.so';
@@ -12,6 +13,7 @@ const PAGE_SIZE = 10;
 
 export default function RecentTips({ addToast }) {
     const { refreshCounter } = useTipContext();
+    const { isDemo, demoTips } = useDemoMode();
     const [tips, setTips] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
@@ -29,6 +31,20 @@ export default function RecentTips({ addToast }) {
     const [totalResults, setTotalResults] = useState(0);
 
     const fetchRecentTips = useCallback(async () => {
+        if (isDemo) {
+            const mapped = demoTips.map(t => ({
+                event: 'tip-sent',
+                sender: t.sender,
+                recipient: t.recipient,
+                amount: t.amount,
+                message: t.message,
+            }));
+            setTips(mapped);
+            setTotalResults(mapped.length);
+            setLoading(false);
+            setLastRefresh(new Date());
+            return;
+        }
         try {
             setError(null);
             const contractId = `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`;

--- a/frontend/src/components/TipHistory.jsx
+++ b/frontend/src/components/TipHistory.jsx
@@ -4,6 +4,7 @@ import { network } from '../utils/stacks';
 import { CONTRACT_ADDRESS, CONTRACT_NAME } from '../config/contracts';
 import { formatSTX, formatAddress } from '../lib/utils';
 import { useTipContext } from '../context/TipContext';
+import { useDemoMode } from '../context/DemoContext';
 import CopyButton from './ui/copy-button';
 import ShareTip from './ShareTip';
 
@@ -21,6 +22,7 @@ const CATEGORY_LABELS = {
 
 export default function TipHistory({ userAddress }) {
     const { refreshCounter } = useTipContext();
+    const { isDemo, demoTips } = useDemoMode();
     const [stats, setStats] = useState(null);
     const [tips, setTips] = useState([]);
     const [loading, setLoading] = useState(true);
@@ -31,6 +33,30 @@ export default function TipHistory({ userAddress }) {
 
     const fetchData = useCallback(async () => {
         if (!userAddress) return;
+
+        // Demo mode: use mock data
+        if (isDemo) {
+            const demoStats = {
+                'tips-sent': { value: '24' },
+                'tips-received': { value: '18' },
+                'total-sent': { value: '156000000' },
+                'total-received': { value: '89000000' },
+            };
+            setStats(demoStats);
+            const mapped = demoTips.map(t => ({
+                event: 'tip-sent',
+                sender: t.sender,
+                recipient: t.recipient,
+                amount: t.amount,
+                message: t.message,
+                category: t.category,
+            }));
+            setTips(mapped);
+            setLoading(false);
+            setLastRefresh(new Date());
+            return;
+        }
+
         try {
             setError(null);
             const [statsResult, tipsResult] = await Promise.all([

--- a/frontend/src/components/ui/animated-hero.jsx
+++ b/frontend/src/components/ui/animated-hero.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
-import { MoveRight, Zap } from "lucide-react";
+import { MoveRight, Zap, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 // Animation configuration for the rotating title text
@@ -8,7 +8,7 @@ const TITLE_ROTATION_INTERVAL_MS = 2000;
 const TITLE_SLIDE_OFFSET_PX = 150;
 const SPRING_STIFFNESS = 50;
 
-function AnimatedHero({ onGetStarted }) {
+function AnimatedHero({ onGetStarted, onTryDemo, loading }) {
     const [titleNumber, setTitleNumber] = useState(0);
     const titles = useMemo(
         () => ["instant", "secure", "transparent", "effortless", "powerful"],
@@ -73,6 +73,7 @@ function AnimatedHero({ onGetStarted }) {
                             size="lg"
                             className="gap-4 bg-slate-900 hover:bg-slate-800 text-white shadow-2xl hover:shadow-slate-200 transition-all transform hover:-translate-y-1 active:scale-95"
                             onClick={onGetStarted}
+                            disabled={loading}
                         >
                             Get Started Now <Zap className="w-4 h-4" />
                         </Button>
@@ -80,11 +81,14 @@ function AnimatedHero({ onGetStarted }) {
                             size="lg"
                             className="gap-4"
                             variant="outline"
-                            onClick={() => window.open('https://github.com/Mosas2000/TipStream#readme', '_blank', 'noopener')}
+                            onClick={onTryDemo}
                         >
-                            Learn More <MoveRight className="w-4 h-4" />
+                            Try Demo <Play className="w-4 h-4" />
                         </Button>
                     </div>
+                    <p className="text-xs text-slate-400 mt-2">
+                        No wallet needed for demo mode
+                    </p>
                 </div>
             </div>
         </div>

--- a/frontend/src/context/DemoContext.jsx
+++ b/frontend/src/context/DemoContext.jsx
@@ -1,0 +1,127 @@
+import { createContext, useContext, useState, useCallback, useMemo } from 'react';
+
+const DemoContext = createContext(null);
+
+// Realistic mock addresses
+const DEMO_ADDRESSES = [
+  'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
+  'SP000000000000000000002Q6VF78',
+  'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE',
+  'SPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S',
+  'SP2C2YFP12AJZB1MATRSD34F5Z6KNPZMC2P3RCXGE',
+];
+
+const DEMO_USER_ADDRESS = 'SP1DEMO000000000000000000000SANDBOX';
+
+const DEMO_CATEGORIES = ['General', 'Content Creation', 'Open Source', 'Community Help', 'Appreciation', 'Education', 'Bug Bounty'];
+
+function generateDemoTips(count = 15) {
+  const messages = [
+    'Great article on Stacks development!',
+    'Thanks for the open source contribution!',
+    'Loved your tutorial on Clarity',
+    'Awesome community support',
+    'Keep up the great work!',
+    'Your documentation was super helpful',
+    'Bug fix saved my project!',
+    'Really enjoyed the livestream',
+    'Best explanation of post-conditions ever',
+    'Incredible smart contract work',
+    'Your NFT marketplace tutorial was perfect',
+    'Thanks for answering my question',
+    'Great podcast episode!',
+    'Your code review was thorough',
+    'Amazing contribution to the ecosystem',
+  ];
+
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    sender: DEMO_ADDRESSES[i % DEMO_ADDRESSES.length],
+    recipient: DEMO_ADDRESSES[(i + 1) % DEMO_ADDRESSES.length],
+    amount: Math.floor(Math.random() * 50_000_000) + 100_000, // 0.1 - 50 STX in microSTX
+    message: messages[i % messages.length],
+    category: i % DEMO_CATEGORIES.length,
+    categoryLabel: DEMO_CATEGORIES[i % DEMO_CATEGORIES.length],
+    blockHeight: 180000 - i * 12,
+    timestamp: Date.now() - i * 3600_000, // 1 hour apart
+  }));
+}
+
+const DEMO_PLATFORM_STATS = {
+  'total-tips': { value: '1247' },
+  'total-volume': { value: '8439000000' }, // 8,439 STX
+  'platform-fees': { value: '42195000' },  // ~42 STX
+  'unique-tippers': { value: '312' },
+};
+
+const DEMO_LEADERBOARD = DEMO_ADDRESSES.map((addr, i) => ({
+  address: addr,
+  totalSent: (500 - i * 80) * 1_000_000,
+  tipCount: 50 - i * 8,
+}));
+
+const DEMO_BALANCE = 125_500_000; // 125.5 STX
+
+let demoTxCounter = 0;
+
+export function DemoProvider({ children }) {
+  const [isDemo, setIsDemo] = useState(false);
+  const [demoTips, setDemoTips] = useState(() => generateDemoTips());
+  const [demoNotifications, setDemoNotifications] = useState([]);
+
+  const enterDemo = useCallback(() => {
+    setIsDemo(true);
+    setDemoTips(generateDemoTips());
+    setDemoNotifications([]);
+    demoTxCounter = 0;
+  }, []);
+
+  const exitDemo = useCallback(() => {
+    setIsDemo(false);
+  }, []);
+
+  const simulateTipSend = useCallback(({ recipient, amount, message, category }) => {
+    demoTxCounter += 1;
+    const fakeTxId = `0xdemo${demoTxCounter.toString().padStart(6, '0')}${'a'.repeat(54)}`;
+    const newTip = {
+      id: Date.now(),
+      sender: DEMO_USER_ADDRESS,
+      recipient,
+      amount,
+      message: message || 'Thanks!',
+      category,
+      categoryLabel: DEMO_CATEGORIES[category] || 'General',
+      blockHeight: 180000 + demoTxCounter,
+      timestamp: Date.now(),
+    };
+    setDemoTips(prev => [newTip, ...prev]);
+    return { txId: fakeTxId, success: true };
+  }, []);
+
+  const value = useMemo(() => ({
+    isDemo,
+    enterDemo,
+    exitDemo,
+    demoTips,
+    demoNotifications,
+    simulateTipSend,
+    demoUserAddress: DEMO_USER_ADDRESS,
+    demoBalance: DEMO_BALANCE,
+    demoPlatformStats: DEMO_PLATFORM_STATS,
+    demoLeaderboard: DEMO_LEADERBOARD,
+  }), [isDemo, enterDemo, exitDemo, demoTips, demoNotifications, simulateTipSend]);
+
+  return (
+    <DemoContext.Provider value={value}>
+      {children}
+    </DemoContext.Provider>
+  );
+}
+
+export function useDemoMode() {
+  const context = useContext(DemoContext);
+  if (!context) {
+    throw new Error('useDemoMode must be used within a DemoProvider');
+  }
+  return context;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,15 +6,18 @@ import App from './App.jsx'
 import ErrorBoundary from './components/ErrorBoundary.jsx'
 import { TipProvider } from './context/TipContext.jsx'
 import { ThemeProvider } from './context/ThemeContext.jsx'
+import { DemoProvider } from './context/DemoContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <ErrorBoundary>
       <BrowserRouter>
         <ThemeProvider>
-          <TipProvider>
-            <App />
-          </TipProvider>
+          <DemoProvider>
+            <TipProvider>
+              <App />
+            </TipProvider>
+          </DemoProvider>
         </ThemeProvider>
       </BrowserRouter>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
Implements a complete demo/sandbox mode allowing users to try TipStream without connecting a wallet or spending real STX. Lowers the barrier for new users and hackathon judges.

## Changes

### New Files
- **DemoContext.jsx**: React context provider with mock data (15 demo tips, platform stats, leaderboard data, 125.5 STX demo balance), simulated tip sending with fake transaction IDs
- **DemoBanner.jsx**: Amber banner indicating demo mode is active with an exit button

### Modified Files
- **animated-hero.jsx**: Added 'Try Demo' button replacing 'Learn More', with 'No wallet needed' hint
- **App.jsx**: Wired DemoProvider, added `handleTryDemo` handler, DemoBanner, treats demo as authenticated
- **main.jsx**: Wrapped app in DemoProvider
- **Header.jsx**: Shows demo wallet indicator and 'Connect Real Wallet' button in demo mode
- **SendTip.jsx**: Simulates tip sending with 800ms delay and fake tx IDs in demo mode
- **PlatformStats.jsx**: Uses mock stats, shows Demo/Live badge
- **Leaderboard.jsx**: Uses mock leaderboard data in demo mode
- **RecentTips.jsx**: Uses mock tip feed in demo mode
- **TipHistory.jsx**: Uses mock user stats and tip history in demo mode

## Testing
- Build succeeds with no errors
- All 46 contract tests pass
- All 61 frontend tests pass

Closes #98