### PR TITLE
fix: minor bugs - dynamic footer year, dead code audit (#215)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -158,7 +158,7 @@ function App() {
       {/* Footer */}
       <footer className="border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
         <div className="max-w-6xl mx-auto px-4 py-6 flex flex-col sm:flex-row justify-between items-center text-gray-400 dark:text-gray-500 text-sm gap-3">
-          <p>&copy; 2026 TipStream</p>
+          <p>&copy; {new Date().getFullYear()} TipStream</p>
           <nav aria-label="Footer links" className="flex gap-6">
             <a href="https://github.com/Mosas2000/TipStream" target="_blank" rel="noopener noreferrer" className="hover:text-gray-900 dark:hover:text-white transition-colors">GitHub</a>
             <a href="https://explorer.hiro.so/txid/SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T.tipstream?chain=mainnet" target="_blank" rel="noopener noreferrer" className="hover:text-gray-900 dark:hover:text-white transition-colors">Contract</a>


### PR DESCRIPTION
## Summary

Fixes the remaining items in #215:

### Changes
1. **Dynamic copyright year** — Replaced hardcoded `© 2026 TipStream` in the footer with `new Date().getFullYear()` so it always reflects the current year.

### Already Resolved (verified)
2. **DemoContext.jsx** — Already deleted in a previous refactoring session. No imports remain.  
3. **button.jsx** — Already deleted. Only `copy-button.jsx` is imported across the codebase.
4. **Public assets** — `favicon.svg` and `logo.svg` both exist in `frontend/public/`. No `og-image.png` reference exists in `index.html` or any component.

Closes #215