### PR TITLE
feat: add NotFound page, robots.txt, and sitemap.xml (#216)

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,7 @@
+# TipStream – robots.txt
+# Allow all crawlers; point to sitemap for discoverability.
+
+User-agent: *
+Allow: /
+
+Sitemap: https://tipstream-silk.vercel.app/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://tipstream-silk.vercel.app/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://tipstream-silk.vercel.app/send</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tipstream-silk.vercel.app/feed</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tipstream-silk.vercel.app/leaderboard</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://tipstream-silk.vercel.app/stats</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, lazy, Suspense } from 'react';
-import { Routes, Route, NavLink, Navigate, useLocation } from 'react-router-dom';
+import { Routes, Route, NavLink, useLocation } from 'react-router-dom';
 import { userSession, authenticate, disconnect } from './utils/stacks';
 import Header from './components/Header';
 import SendTip from './components/SendTip';
@@ -16,6 +16,7 @@ const TipHistory = lazy(() => import('./components/TipHistory'));
 const PlatformStats = lazy(() => import('./components/PlatformStats'));
 const RecentTips = lazy(() => import('./components/RecentTips'));
 const Leaderboard = lazy(() => import('./components/Leaderboard'));
+const NotFound = lazy(() => import('./components/NotFound'));
 
 function App() {
   const [userData, setUserData] = useState(null);
@@ -146,7 +147,7 @@ function App() {
                 <Route path="/leaderboard" element={<Leaderboard />} />
                 <Route path="/activity" element={<TipHistory userAddress={userData.profile.stxAddress.mainnet} />} />
                 <Route path="/stats" element={<PlatformStats />} />
-                <Route path="*" element={<Navigate to="/send" replace />} />
+                <Route path="*" element={<NotFound />} />
               </Routes>
             </Suspense>
           </div>

--- a/frontend/src/components/NotFound.jsx
+++ b/frontend/src/components/NotFound.jsx
@@ -1,0 +1,33 @@
+import { Link } from 'react-router-dom';
+
+/**
+ * 404 – Not Found page.
+ *
+ * Displayed for any route that does not match a defined path.
+ * Offers a clear message and a link back to the main Send Tip view.
+ */
+export default function NotFound() {
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-4">
+      <div className="text-center max-w-md">
+        <p className="text-7xl font-black text-gray-200 dark:text-gray-800 select-none">404</p>
+
+        <h1 className="mt-4 text-2xl font-bold text-gray-900 dark:text-white">
+          Page not found
+        </h1>
+
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+          The page you&rsquo;re looking for doesn&rsquo;t exist or has been
+          moved. Check the URL or head back to the app.
+        </p>
+
+        <Link
+          to="/send"
+          className="inline-flex items-center gap-2 mt-6 px-6 py-2.5 bg-gray-900 dark:bg-amber-500 text-white dark:text-black text-sm font-semibold rounded-xl hover:opacity-90 transition-opacity"
+        >
+          Go to Send Tip
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Addresses all items in #216:

### Changes
1. **NotFound.jsx** — New 404 page component with clear messaging and a link back to `/send`. Replaces the silent `<Navigate to="/send" replace />` catch-all route.
2. **robots.txt** — Added to `frontend/public/` allowing all crawlers, with a sitemap reference.
3. **sitemap.xml** — Added to `frontend/public/` listing all SPA routes (`/`, `/send`, `/feed`, `/leaderboard`, `/stats`) with appropriate change frequencies.

### Already Resolved
4. **.env.example** — Already exists at `frontend/.env.example` with documented variables (`VITE_NETWORK`, `VITE_APP_URL`).

### Files Changed
- `frontend/src/App.jsx` — Added `NotFound` lazy import, replaced catch-all redirect, removed unused `Navigate` import
- `frontend/src/components/NotFound.jsx` — New file
- `frontend/public/robots.txt` — New file
- `frontend/public/sitemap.xml` — New file

Closes #216