### PR TITLE
fix: implement API pagination for contract event fetching (#214)

### DIFF
--- a/frontend/src/components/Leaderboard.jsx
+++ b/frontend/src/components/Leaderboard.jsx
@@ -14,6 +14,9 @@ const MEDALS = [
 ];
 const DEFAULT_MEDAL = 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400';
 
+const API_LIMIT = 50;
+const MAX_AUTO_PAGES = 10; // Auto-fetch up to 500 events on initial load
+
 /**
  * Leaderboard component that ranks users by total STX sent or received.
  *
@@ -27,9 +30,14 @@ export default function Leaderboard() {
     const { refreshCounter } = useTipContext();
     const [leaders, setLeaders] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [loadingMore, setLoadingMore] = useState(false);
     const [error, setError] = useState(null);
     const [tab, setTab] = useState('sent');
     const [lastRefresh, setLastRefresh] = useState(null);
+    const [allTipEvents, setAllTipEvents] = useState([]);
+    const [apiOffset, setApiOffset] = useState(0);
+    const [hasMore, setHasMore] = useState(false);
+    const [totalApiEvents, setTotalApiEvents] = useState(null);
 
     const fetchLeaderboard = useCallback(async () => {
         if (loading && leaders.length > 0) return;
@@ -37,17 +45,35 @@ export default function Leaderboard() {
             setLoading(true);
             setError(null);
             const contractId = `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`;
-            const response = await fetch(`${STACKS_API_BASE}/extended/v1/contract/${contractId}/events?limit=50&offset=0`);
-            if (!response.ok) throw new Error(`API returned ${response.status}`);
 
-            const data = await response.json();
+            // Auto-paginate through multiple pages for accurate rankings
+            let accumulated = [];
+            let currentOffset = 0;
+            let totalEvents = null;
 
-            const tipEvents = data.results
+            for (let page = 0; page < MAX_AUTO_PAGES; page++) {
+                const response = await fetch(`${STACKS_API_BASE}/extended/v1/contract/${contractId}/events?limit=${API_LIMIT}&offset=${currentOffset}`);
+                if (!response.ok) throw new Error(`API returned ${response.status}`);
+
+                const data = await response.json();
+                totalEvents = data.total;
+                accumulated = accumulated.concat(data.results);
+                currentOffset += data.results.length;
+
+                // Stop if we've fetched all events
+                if (currentOffset >= data.total || data.results.length < API_LIMIT) break;
+            }
+
+            const tipEvents = accumulated
                 .filter(e => e.contract_log?.value?.repr)
                 .map(e => parseTipEvent(e.contract_log.value.repr))
                 .filter(t => t !== null && t.event === 'tip-sent' && t.sender && t.recipient && t.amount !== '0');
 
+            setAllTipEvents(tipEvents);
             setLeaders(buildLeaderboardStats(tipEvents));
+            setApiOffset(currentOffset);
+            setHasMore(currentOffset < totalEvents);
+            setTotalApiEvents(totalEvents);
             setLoading(false);
             setLastRefresh(new Date());
         } catch (err) {
@@ -57,6 +83,42 @@ export default function Leaderboard() {
             setLoading(false);
         }
     }, []);
+
+    const loadMoreEvents = useCallback(async () => {
+        try {
+            setLoadingMore(true);
+            const contractId = `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`;
+
+            let accumulated = [];
+            let currentOffset = apiOffset;
+
+            for (let page = 0; page < MAX_AUTO_PAGES; page++) {
+                const response = await fetch(`${STACKS_API_BASE}/extended/v1/contract/${contractId}/events?limit=${API_LIMIT}&offset=${currentOffset}`);
+                if (!response.ok) throw new Error(`API returned ${response.status}`);
+
+                const data = await response.json();
+                accumulated = accumulated.concat(data.results);
+                currentOffset += data.results.length;
+
+                if (currentOffset >= data.total || data.results.length < API_LIMIT) break;
+            }
+
+            const newTipEvents = accumulated
+                .filter(e => e.contract_log?.value?.repr)
+                .map(e => parseTipEvent(e.contract_log.value.repr))
+                .filter(t => t !== null && t.event === 'tip-sent' && t.sender && t.recipient && t.amount !== '0');
+
+            const combinedEvents = [...allTipEvents, ...newTipEvents];
+            setAllTipEvents(combinedEvents);
+            setLeaders(buildLeaderboardStats(combinedEvents));
+            setApiOffset(currentOffset);
+            setHasMore(currentOffset < (totalApiEvents || Infinity));
+        } catch (err) {
+            console.error('Failed to load more leaderboard data:', err.message || err);
+        } finally {
+            setLoadingMore(false);
+        }
+    }, [apiOffset, allTipEvents, totalApiEvents]);
 
     useEffect(() => { fetchLeaderboard(); }, [fetchLeaderboard, refreshCounter]);
     useEffect(() => { const i = setInterval(fetchLeaderboard, 60000); return () => clearInterval(i); }, [fetchLeaderboard]);
@@ -131,10 +193,22 @@ export default function Leaderboard() {
                 )}
                 {sorted.length > 0 && (
                     <div className="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 flex justify-between items-center px-3">
-                        <span className="text-xs text-gray-400">Showing top {sorted.length} users</span>
+                        <span className="text-xs text-gray-400">Showing top {sorted.length} users{totalApiEvents !== null ? ` (from ${allTipEvents.length} events of ${totalApiEvents} total)` : ''}</span>
                         <span className="text-xs font-semibold text-gray-500 dark:text-gray-400">
                             Total: {formatSTX(sorted.reduce((sum, u) => sum + (tab === 'sent' ? u.totalSent : u.totalReceived), 0), 2)} STX
                         </span>
+                    </div>
+                )}
+
+                {hasMore && (
+                    <div className="mt-3 text-center">
+                        <button 
+                            onClick={loadMoreEvents} 
+                            disabled={loadingMore}
+                            className="px-4 py-2 text-xs font-semibold bg-amber-500 hover:bg-amber-600 disabled:bg-gray-300 dark:disabled:bg-gray-700 text-white rounded-lg transition-colors"
+                        >
+                            {loadingMore ? 'Loading more events…' : 'Load More Events for Accurate Rankings'}
+                        </button>
                     </div>
                 )}
             </div>

--- a/frontend/src/components/RecentTips.jsx
+++ b/frontend/src/components/RecentTips.jsx
@@ -11,11 +11,13 @@ import { Zap, Search } from 'lucide-react';
 import CopyButton from './ui/copy-button';
 
 const PAGE_SIZE = 10;
+const API_LIMIT = 50;
 
 export default function RecentTips({ addToast }) {
     const { refreshCounter } = useTipContext();
     const [tips, setTips] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [loadingMore, setLoadingMore] = useState(false);
     const [messagesLoading, setMessagesLoading] = useState(false);
     const [error, setError] = useState(null);
     const [tipBackTarget, setTipBackTarget] = useState(null);
@@ -29,13 +31,16 @@ export default function RecentTips({ addToast }) {
     const [sortBy, setSortBy] = useState('newest');
     const [showFilters, setShowFilters] = useState(false);
     const [offset, setOffset] = useState(0);
+    const [apiOffset, setApiOffset] = useState(0);
+    const [hasMore, setHasMore] = useState(false);
+    const [totalApiEvents, setTotalApiEvents] = useState(null);
 
     const fetchRecentTips = useCallback(async () => {
         try {
             setError(null);
             clearTipCache();
             const contractId = `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`;
-            const response = await fetch(`${STACKS_API_BASE}/extended/v1/contract/${contractId}/events?limit=50&offset=0`);
+            const response = await fetch(`${STACKS_API_BASE}/extended/v1/contract/${contractId}/events?limit=${API_LIMIT}&offset=0`);
             if (!response.ok) throw new Error(`API returned ${response.status}`);
 
             const data = await response.json();
@@ -45,6 +50,9 @@ export default function RecentTips({ addToast }) {
                 .filter(t => t !== null && t.event === 'tip-sent');
 
             setTips(tipEvents);
+            setApiOffset(data.results.length);
+            setHasMore(data.offset + data.results.length < data.total);
+            setTotalApiEvents(data.total);
             setLoading(false);
             setLastRefresh(new Date());
 
@@ -71,6 +79,43 @@ export default function RecentTips({ addToast }) {
             setLoading(false);
         }
     }, []);
+
+    const loadMoreTips = useCallback(async () => {
+        try {
+            setLoadingMore(true);
+            const contractId = `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`;
+            const response = await fetch(`${STACKS_API_BASE}/extended/v1/contract/${contractId}/events?limit=${API_LIMIT}&offset=${apiOffset}`);
+            if (!response.ok) throw new Error(`API returned ${response.status}`);
+
+            const data = await response.json();
+            const newTipEvents = data.results
+                .filter(e => e.contract_log?.value?.repr)
+                .map(e => parseTipEvent(e.contract_log.value.repr))
+                .filter(t => t !== null && t.event === 'tip-sent');
+
+            setTips(prev => [...prev, ...newTipEvents]);
+            setApiOffset(prev => prev + data.results.length);
+            setHasMore(data.offset + data.results.length < data.total);
+
+            // Fetch messages for new tips
+            const tipIds = newTipEvents.map(t => t.tipId).filter(id => id && id !== '0');
+            if (tipIds.length > 0) {
+                try {
+                    const messageMap = await fetchTipMessages(tipIds);
+                    setTips(prev => prev.map(t => {
+                        const msg = messageMap.get(String(t.tipId));
+                        return msg ? { ...t, message: msg } : t;
+                    }));
+                } catch (msgErr) {
+                    console.warn('Failed to fetch tip messages:', msgErr.message || msgErr);
+                }
+            }
+        } catch (err) {
+            console.error('Failed to load more tips:', err.message || err);
+        } finally {
+            setLoadingMore(false);
+        }
+    }, [apiOffset]);
 
     useEffect(() => { fetchRecentTips(); }, [fetchRecentTips, refreshCounter]);
     useEffect(() => { const i = setInterval(fetchRecentTips, 60000); return () => clearInterval(i); }, [fetchRecentTips]);
@@ -186,7 +231,8 @@ export default function RecentTips({ addToast }) {
                         </div>
                     </div>
                 )}
-                {hasActiveFilters && <p className="text-xs text-gray-500 dark:text-gray-400">Showing {filteredTips.length} of {tips.length} tips</p>}
+                {hasActiveFilters && <p className="text-xs text-gray-500 dark:text-gray-400">Showing {filteredTips.length} of {tips.length} tips{totalApiEvents !== null && totalApiEvents > tips.length ? ` (${totalApiEvents} total on-chain)` : ''}</p>}
+                {!hasActiveFilters && totalApiEvents !== null && <p className="text-xs text-gray-500 dark:text-gray-400">Loaded {tips.length} of {totalApiEvents} on-chain events</p>}
             </div>
 
             {/* Tip cards */}
@@ -241,6 +287,16 @@ export default function RecentTips({ addToast }) {
                     <span className="text-xs text-gray-500 dark:text-gray-400">Page {currentPage} of {totalPages}</span>
                     <button onClick={() => setOffset(Math.min((totalPages - 1) * PAGE_SIZE, offset + PAGE_SIZE))} disabled={currentPage >= totalPages}
                         className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg transition-colors disabled:opacity-40">Next</button>
+                </div>
+            )}
+
+            {/* Load More from API */}
+            {hasMore && (
+                <div className="flex justify-center mt-4">
+                    <button onClick={loadMoreTips} disabled={loadingMore}
+                        className="px-6 py-2.5 text-sm font-semibold bg-gray-900 dark:bg-amber-500 text-white dark:text-black rounded-xl hover:opacity-90 transition-opacity disabled:opacity-50">
+                        {loadingMore ? 'Loading...' : 'Load More Tips'}
+                    </button>
                 </div>
             )}
 

--- a/frontend/src/components/TipHistory.jsx
+++ b/frontend/src/components/TipHistory.jsx
@@ -14,16 +14,22 @@ const CATEGORY_LABELS = {
     3: 'Community Help', 4: 'Appreciation', 5: 'Education', 6: 'Bug Bounty',
 };
 
+const API_LIMIT = 50;
+
 export default function TipHistory({ userAddress }) {
     const { refreshCounter } = useTipContext();
     const [stats, setStats] = useState(null);
     const [tips, setTips] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [loadingMore, setLoadingMore] = useState(false);
     const [messagesLoading, setMessagesLoading] = useState(false);
     const [error, setError] = useState(null);
     const [tab, setTab] = useState('all');
     const [categoryFilter, setCategoryFilter] = useState('all');
     const [lastRefresh, setLastRefresh] = useState(null);
+    const [apiOffset, setApiOffset] = useState(0);
+    const [hasMore, setHasMore] = useState(false);
+    const [totalApiEvents, setTotalApiEvents] = useState(null);
 
     const fetchData = useCallback(async () => {
         if (!userAddress) return;
@@ -35,7 +41,7 @@ export default function TipHistory({ userAddress }) {
                     network, contractAddress: CONTRACT_ADDRESS, contractName: CONTRACT_NAME,
                     functionName: 'get-user-stats', functionArgs: [principalCV(userAddress)], senderAddress: userAddress,
                 }),
-                fetch(`${STACKS_API_BASE}/extended/v1/contract/${CONTRACT_ADDRESS}.${CONTRACT_NAME}/events?limit=50&offset=0`)
+                fetch(`${STACKS_API_BASE}/extended/v1/contract/${CONTRACT_ADDRESS}.${CONTRACT_NAME}/events?limit=${API_LIMIT}&offset=0`)
                     .then(r => { if (!r.ok) throw new Error(`API returned ${r.status}`); return r.json(); })
             ]);
 
@@ -55,6 +61,9 @@ export default function TipHistory({ userAddress }) {
                 .map(t => ({ ...t, direction: t.sender === userAddress ? 'sent' : 'received', category: categoryMap[t.tipId] ?? null }));
 
             setTips(userTips);
+            setApiOffset(tipsResult.results.length);
+            setHasMore(tipsResult.offset + tipsResult.results.length < tipsResult.total);
+            setTotalApiEvents(tipsResult.total);
             setLoading(false);
             setLastRefresh(new Date());
 
@@ -81,6 +90,51 @@ export default function TipHistory({ userAddress }) {
             setLoading(false);
         }
     }, [userAddress]);
+
+    const loadMoreTips = useCallback(async () => {
+        if (!userAddress) return;
+        try {
+            setLoadingMore(true);
+            const response = await fetch(`${STACKS_API_BASE}/extended/v1/contract/${CONTRACT_ADDRESS}.${CONTRACT_NAME}/events?limit=${API_LIMIT}&offset=${apiOffset}`);
+            if (!response.ok) throw new Error(`API returned ${response.status}`);
+
+            const data = await response.json();
+            const allEvents = data.results
+                .filter(e => e.contract_log?.value?.repr)
+                .map(e => parseTipEvent(e.contract_log.value.repr))
+                .filter(Boolean);
+
+            const categoryMap = {};
+            allEvents.filter(e => e.event === 'tip-categorized').forEach(e => { categoryMap[e.tipId] = Number(e.category || 0); });
+
+            const newUserTips = allEvents
+                .filter(t => t.event === 'tip-sent')
+                .filter(t => t.sender === userAddress || t.recipient === userAddress)
+                .map(t => ({ ...t, direction: t.sender === userAddress ? 'sent' : 'received', category: categoryMap[t.tipId] ?? null }));
+
+            setTips(prev => [...prev, ...newUserTips]);
+            setApiOffset(prev => prev + data.results.length);
+            setHasMore(data.offset + data.results.length < data.total);
+
+            // Fetch messages for new tips
+            const tipIds = newUserTips.map(t => t.tipId).filter(id => id && id !== '0');
+            if (tipIds.length > 0) {
+                try {
+                    const messageMap = await fetchTipMessages(tipIds);
+                    setTips(prev => prev.map(t => {
+                        const msg = messageMap.get(String(t.tipId));
+                        return msg ? { ...t, message: msg } : t;
+                    }));
+                } catch (msgErr) {
+                    console.warn('Failed to fetch tip messages:', msgErr.message || msgErr);
+                }
+            }
+        } catch (err) {
+            console.error('Failed to load more tips:', err.message || err);
+        } finally {
+            setLoadingMore(false);
+        }
+    }, [userAddress, apiOffset]);
 
     useEffect(() => { fetchData(); }, [fetchData, refreshCounter]);
     useEffect(() => { const i = setInterval(fetchData, 60000); return () => clearInterval(i); }, [fetchData]);
@@ -191,6 +245,19 @@ export default function TipHistory({ userAddress }) {
                     </div>
                 )}
             </div>
+
+            {/* Load More from API */}
+            {hasMore && (
+                <div className="flex flex-col items-center gap-2 mt-4">
+                    <button onClick={loadMoreTips} disabled={loadingMore}
+                        className="px-6 py-2.5 text-sm font-semibold bg-gray-900 dark:bg-amber-500 text-white dark:text-black rounded-xl hover:opacity-90 transition-opacity disabled:opacity-50">
+                        {loadingMore ? 'Loading...' : 'Load More Activity'}
+                    </button>
+                    {totalApiEvents !== null && (
+                        <span className="text-xs text-gray-400">Showing {tips.length} of {totalApiEvents} on-chain events</span>
+                    )}
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Resolves #214 — Contract event fetching was limited to 50 results with no API pagination.

## Changes

### RecentTips.jsx
- Added `API_LIMIT` constant and pagination state (`apiOffset`, `hasMore`, `loadingMore`, `totalApiEvents`)
- Initial fetch at offset=0; new `loadMoreTips` callback fetches next page and appends results
- "Load More Tips" button appears when more events are available
- Displays total event count from API

### TipHistory.jsx
- Same pagination pattern as RecentTips
- `loadMoreTips` callback fetches next page, filters by user address, and appends
- "Load More Activity" button with event count display

### Leaderboard.jsx
- Auto-paginates through up to 10 pages (500 events) on initial load for accurate rankings
- `loadMoreEvents` callback fetches additional pages and rebuilds leaderboard stats
- "Load More Events for Accurate Rankings" button when more data exist- "Load More Events for Accurate Rankings" button when more data exist- "Load More Events for Accurate ndle API errors gracefully
- Loading states shown during pagination
- Buttons disabled during loading to pre- Buttons disabches
- No lint errors