### PR TITLE
Add wallet session refresh tests

### DIFF
--- a/frontend/src/components/BlockManager.jsx
+++ b/frontend/src/components/BlockManager.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { openContractCall } from '@stacks/connect';
 import {
     fetchCallReadOnlyFunction,
@@ -6,10 +6,11 @@ import {
     principalCV,
     PostConditionMode,
 } from '@stacks/transactions';
-import { network, appDetails, getSenderAddress } from '../utils/stacks';
+import { network, appDetails } from '../utils/stacks';
 import { CONTRACT_ADDRESS, CONTRACT_NAME, FN_IS_USER_BLOCKED, FN_TOGGLE_BLOCK_USER } from '../config/contracts';
 import { formatAddress } from '../lib/utils';
 import { ShieldBan, Search, UserX, UserCheck, Loader2 } from 'lucide-react';
+import { useSenderAddress } from '../hooks/useSenderAddress';
 
 export default function BlockManager({ addToast }) {
     const [addressInput, setAddressInput] = useState('');
@@ -18,7 +19,7 @@ export default function BlockManager({ addToast }) {
     const [toggling, setToggling] = useState(false);
     const [blockedList, setBlockedList] = useState([]);
 
-    const senderAddress = useMemo(() => getSenderAddress(), []);
+    const senderAddress = useSenderAddress();
 
     const isValidStacksAddress = (address) => {
         if (!address) return false;

--- a/frontend/src/test/wallet-session-refresh.test.jsx
+++ b/frontend/src/test/wallet-session-refresh.test.jsx
@@ -1,22 +1,113 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SendTip from '../components/SendTip';
 import TokenTip from '../components/TokenTip';
 import BatchTip from '../components/BatchTip';
-import * as blockCheckHook from '../hooks/useBlockCheck';
-import * as balanceHook from '../hooks/useBalance';
-import * as stxPriceHook from '../hooks/useStxPrice';
-import * as demoModeHook from '../context/DemoContext';
-import * as tipContextHook from '../context/TipContext';
+import BlockManager from '../components/BlockManager';
+import * as transactions from '@stacks/transactions';
 
-const sessionState = vi.hoisted(() => ({
+const mocks = vi.hoisted(() => {
+  const state = {
     currentSenderAddress: 'SP1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  };
+
+  const openContractCall = vi.fn(async (args) => {
+    args.onFinish?.({ txId: '0xabc' });
+  });
+
+  const fetchCallReadOnlyFunction = vi.fn(async () => ({}));
+  const cvToJSON = vi.fn(() => ({ value: true }));
+  const tipPostCondition = vi.fn((senderAddress, amountMicroSTX) => ({
+    senderAddress,
+    amountMicroSTX,
+  }));
+  const pcPrincipal = vi.fn((senderAddress) => ({
+    willSendLte: vi.fn((amount) => ({
+      ustx: vi.fn(() => ({ senderAddress, amount, kind: 'ustx' })),
+      ft: vi.fn(() => ({ senderAddress, amount, kind: 'ft' })),
+    })),
+  }));
+
+  return {
+    state,
+    openContractCall,
+    fetchCallReadOnlyFunction,
+    cvToJSON,
+    tipPostCondition,
+    pcPrincipal,
+  };
+});
+
+vi.mock('@stacks/connect', () => ({
+  openContractCall: mocks.openContractCall,
 }));
 
-const mockOpenContractCall = vi.hoisted(() => vi.fn());
-const mockNotifyTipSent = vi.hoisted(() => vi.fn());
-const mockUseSendTipWithDemo = vi.hoisted(() => vi.fn());
-const mockAnalytics = vi.hoisted(() => ({
+vi.mock('@stacks/transactions', () => ({
+  fetchCallReadOnlyFunction: mocks.fetchCallReadOnlyFunction,
+  cvToJSON: mocks.cvToJSON,
+  principalCV: vi.fn((value) => value),
+  stringUtf8CV: vi.fn((value) => value),
+  uintCV: vi.fn((value) => value),
+  contractPrincipalCV: vi.fn((address, name) => `${address}.${name}`),
+  listCV: vi.fn((value) => value),
+  tupleCV: vi.fn((value) => value),
+  PostConditionMode: { Deny: 'deny' },
+  Pc: { principal: mocks.pcPrincipal },
+}));
+
+vi.mock('../lib/post-conditions', async () => {
+  const actual = await vi.importActual('../lib/post-conditions');
+  return {
+    ...actual,
+    tipPostCondition: mocks.tipPostCondition,
+  };
+});
+
+vi.mock('../hooks/useSenderAddress', () => ({
+  useSenderAddress: vi.fn(() => mocks.state.currentSenderAddress),
+}));
+
+vi.mock('../hooks/useBlockCheck', () => ({
+  useBlockCheck: vi.fn(() => ({
+    blocked: false,
+    checking: false,
+    checkBlocked: vi.fn(),
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock('../hooks/useBalance', () => ({
+  useBalance: vi.fn(() => ({
+    balance: '1000000000',
+    balanceStx: 1000,
+    loading: false,
+    refetch: vi.fn(),
+  })),
+}));
+
+vi.mock('../hooks/useStxPrice', () => ({
+  useStxPrice: vi.fn(() => ({
+    toUsd: vi.fn(() => '50.00'),
+  })),
+}));
+
+vi.mock('../context/DemoContext', () => ({
+  useDemoMode: vi.fn(() => ({
+    demoEnabled: false,
+    getDemoData: vi.fn(() => ({ mockWalletAddress: mocks.state.currentSenderAddress })),
+    toggleDemo: vi.fn(),
+  })),
+}));
+
+vi.mock('../context/TipContext', () => ({
+  useTipContext: vi.fn(() => ({
+    notifyTipSent: vi.fn(),
+  })),
+}));
+
+vi.mock('../lib/analytics', () => ({
+  analytics: {
     trackTipStarted: vi.fn(),
     trackTipSubmitted: vi.fn(),
     trackTipConfirmed: vi.fn(),
@@ -28,138 +119,176 @@ const mockAnalytics = vi.hoisted(() => ({
     trackBatchTipCancelled: vi.fn(),
     trackBatchTipFailed: vi.fn(),
     trackBatchTipConfirmed: vi.fn(),
+  },
 }));
 
-vi.mock('@stacks/connect', () => ({
-    openContractCall: (...args) => mockOpenContractCall(...args),
+vi.mock('../components/ui/confirm-dialog', () => ({
+  default: ({ open, title, children, onConfirm, onCancel, confirmLabel }) =>
+    open ? (
+      <div role="dialog" aria-label={title}>
+        <div>{children}</div>
+        <button onClick={onConfirm}>{confirmLabel}</button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    ) : null,
 }));
 
-vi.mock('../hooks/useSenderAddress', () => ({
-    useSenderAddress: vi.fn(() => sessionState.currentSenderAddress),
-}));
-
-vi.mock('../hooks/useBlockCheck', () => ({
-    useBlockCheck: vi.fn(),
-}));
-
-vi.mock('../hooks/useBalance', () => ({
-    useBalance: vi.fn(),
-}));
-
-vi.mock('../hooks/useSendTipWithDemo', () => ({
-    useSendTipWithDemo: (...args) => mockUseSendTipWithDemo(...args),
-}));
-
-vi.mock('../hooks/useStxPrice', () => ({
-    useStxPrice: vi.fn(),
-}));
-
-vi.mock('../context/DemoContext', () => ({
-    useDemoMode: vi.fn(),
-}));
-
-vi.mock('../context/TipContext', () => ({
-    useTipContext: vi.fn(),
-}));
-
-vi.mock('../lib/analytics', () => ({
-    analytics: mockAnalytics,
+vi.mock('../components/ui/tx-status', () => ({
+  default: () => <div data-testid="tx-status" />,
 }));
 
 vi.mock('../utils/stacks', () => ({
-    network: { id: 'testnet' },
-    appDetails: { name: 'TipStream' },
+  network: { id: 'testnet' },
+  appDetails: { name: 'TipStream' },
 }));
 
+beforeEach(() => {
+  mocks.state.currentSenderAddress = 'SP1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+  mocks.openContractCall.mockClear();
+  mocks.fetchCallReadOnlyFunction.mockClear();
+  mocks.cvToJSON.mockClear();
+  mocks.tipPostCondition.mockClear();
+  mocks.pcPrincipal.mockClear();
+});
+
 describe('wallet session refresh', () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-        sessionState.currentSenderAddress = 'SP1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
-        vi.mocked(blockCheckHook.useBlockCheck).mockReturnValue({
-            blocked: false,
-            checking: false,
-            checkBlocked: vi.fn(),
-            reset: vi.fn(),
-        });
-        vi.mocked(balanceHook.useBalance).mockReturnValue({
-            balance: '1000000000',
-            balanceStx: 1000,
-            loading: false,
-            refetch: vi.fn(),
-        });
-        vi.mocked(stxPriceHook.useStxPrice).mockReturnValue({
-            toUsd: vi.fn().mockReturnValue('50.00'),
-        });
-        vi.mocked(demoModeHook.useDemoMode).mockReturnValue({
-            demoEnabled: false,
-            getDemoData: vi.fn(() => ({ mockWalletAddress: sessionState.currentSenderAddress })),
-            toggleDemo: vi.fn(),
-        });
-        vi.mocked(tipContextHook.useTipContext).mockReturnValue({
-            notifyTipSent: mockNotifyTipSent,
-        });
-        mockUseSendTipWithDemo.mockReturnValue({
-            displayBalance: '1000000000',
-            sendTipInDemo: vi.fn(),
-            pendingTransaction: null,
-        });
+  it('updates SendTip validation when the sender changes', async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(<SendTip addToast={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Recipient Address'), mocks.state.currentSenderAddress);
+
+    await waitFor(() => {
+      expect(screen.getByText('You cannot send a tip to yourself')).toBeInTheDocument();
     });
 
-    afterEach(() => {
-        mockOpenContractCall.mockReset();
+    mocks.state.currentSenderAddress = 'SP2BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+    rerender(<SendTip addToast={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('You cannot send a tip to yourself')).toBeNull();
+    });
+  });
+
+  it('uses the current sender in SendTip post conditions after account switch', async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(<SendTip addToast={vi.fn()} />);
+
+    mocks.state.currentSenderAddress = 'SP2BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+    rerender(<SendTip addToast={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Recipient Address'), 'SP3CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC');
+    await user.type(screen.getByLabelText('Amount (STX)'), '1');
+    await user.click(screen.getByRole('button', { name: 'Send Tip' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Confirm Tip' });
+    await user.click(within(dialog).getByRole('button', { name: 'Send Tip' }));
+
+    expect(mocks.tipPostCondition).toHaveBeenCalledWith(mocks.state.currentSenderAddress, 1000000);
+  });
+
+  it('updates TokenTip validation when the sender changes', async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(<TokenTip addToast={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Recipient Address'), mocks.state.currentSenderAddress);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cannot send a tip to yourself')).toBeInTheDocument();
     });
 
-    it('updates SendTip sender validation when the session changes', async () => {
-        const { rerender } = render(<SendTip addToast={vi.fn()} />);
+    mocks.state.currentSenderAddress = 'SP3CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+    rerender(<TokenTip addToast={vi.fn()} />);
 
-        fireEvent.change(screen.getByPlaceholderText('SP2...'), {
-            target: { value: sessionState.currentSenderAddress },
-        });
-        await waitFor(() => {
-            expect(screen.getByText('You cannot send a tip to yourself')).toBeInTheDocument();
-        });
+    await waitFor(() => {
+      expect(screen.queryByText('Cannot send a tip to yourself')).toBeNull();
+    });
+  });
 
-        sessionState.currentSenderAddress = 'SP2BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
-        rerender(<SendTip addToast={vi.fn()} />);
+  it('uses the current sender in TokenTip post conditions after account switch', async () => {
+    const user = userEvent.setup();
 
-        await waitFor(() => {
-            expect(screen.queryByText('You cannot send a tip to yourself')).toBeNull();
-        });
+    const { rerender } = render(<TokenTip addToast={vi.fn()} />);
+
+    mocks.state.currentSenderAddress = 'SP3CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+    rerender(<TokenTip addToast={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Token Contract'), 'SP2RDS2YKXMFSP4H9Q5D1FXF5K5J91TH1P5KH3HVP.token');
+    await user.click(screen.getByRole('button', { name: 'Check whitelist status' }));
+    await waitFor(() => {
+      expect(screen.getByText('Token is whitelisted')).toBeInTheDocument();
+    });
+    await user.type(screen.getByLabelText('Recipient Address'), 'SP4DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD');
+    await user.type(screen.getByLabelText('Amount (smallest token unit)'), '100');
+    await user.click(screen.getByRole('button', { name: 'Send Token Tip' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Confirm Token Tip' });
+    await user.click(within(dialog).getByRole('button', { name: 'Send Token Tip' }));
+
+    expect(mocks.openContractCall).toHaveBeenCalled();
+    expect(transactions.Pc.principal).toHaveBeenCalledWith(mocks.state.currentSenderAddress);
+  });
+
+  it('updates BatchTip validation when the sender changes', async () => {
+    const { rerender } = render(<BatchTip addToast={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText('SP2... recipient address'), {
+      target: { value: mocks.state.currentSenderAddress },
+    });
+    fireEvent.change(screen.getByPlaceholderText('STX'), { target: { value: '1' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Cannot tip yourself')).toBeInTheDocument();
     });
 
-    it('updates TokenTip sender validation when the session changes', async () => {
-        const { rerender } = render(<TokenTip addToast={vi.fn()} />);
+    mocks.state.currentSenderAddress = 'SP4DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
+    rerender(<BatchTip addToast={vi.fn()} />);
 
-        fireEvent.change(screen.getByPlaceholderText('SP2...'), {
-            target: { value: sessionState.currentSenderAddress },
-        });
-        await waitFor(() => {
-            expect(screen.getByText('Cannot send a tip to yourself')).toBeInTheDocument();
-        });
-
-        sessionState.currentSenderAddress = 'SP3CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
-        rerender(<TokenTip addToast={vi.fn()} />);
-
-        await waitFor(() => {
-            expect(screen.queryByText('Cannot send a tip to yourself')).toBeNull();
-        });
+    await waitFor(() => {
+      expect(screen.queryByText('Cannot tip yourself')).toBeNull();
     });
+  });
 
-    it('updates BatchTip sender validation when the session changes', async () => {
-        const { rerender } = render(<BatchTip addToast={vi.fn()} />);
+  it('uses the current sender in BatchTip post conditions after account switch', async () => {
+    const { rerender } = render(<BatchTip addToast={vi.fn()} />);
 
-        fireEvent.change(screen.getByPlaceholderText('SP2... recipient address'), {
-            target: { value: sessionState.currentSenderAddress },
-        });
-        await waitFor(() => {
-            expect(screen.getByText('Cannot tip yourself')).toBeInTheDocument();
-        });
+    mocks.state.currentSenderAddress = 'SP4DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
+    rerender(<BatchTip addToast={vi.fn()} />);
 
-        sessionState.currentSenderAddress = 'SP4DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
-        rerender(<BatchTip addToast={vi.fn()} />);
-
-        await waitFor(() => {
-            expect(screen.queryByText('Cannot tip yourself')).toBeNull();
-        });
+    fireEvent.change(screen.getByPlaceholderText('SP2... recipient address'), {
+      target: { value: 'SP5EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE' },
     });
+    fireEvent.change(screen.getByPlaceholderText('STX'), { target: { value: '1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send 1 Tip' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Confirm Batch Tips' });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Send 1 Tip' }));
+
+    expect(mocks.openContractCall).toHaveBeenCalled();
+    expect(transactions.Pc.principal).toHaveBeenCalledWith(mocks.state.currentSenderAddress);
+  });
+
+  it('uses the current sender in block checks after account switch', async () => {
+    const { rerender } = render(<BlockManager addToast={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('User Address'), {
+      target: { value: mocks.state.currentSenderAddress },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Check block status' }));
+
+    expect(mocks.fetchCallReadOnlyFunction).not.toHaveBeenCalled();
+
+    mocks.state.currentSenderAddress = 'SP6FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF';
+    rerender(<BlockManager addToast={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check block status' }));
+
+    await waitFor(() => {
+      expect(mocks.fetchCallReadOnlyFunction).toHaveBeenCalled();
+    });
+    expect(mocks.fetchCallReadOnlyFunction.mock.calls.at(-1)[0].senderAddress).toBe(mocks.state.currentSenderAddress);
+  });
 });


### PR DESCRIPTION
Add wallet session refresh coverage for sender-aware forms

Description:
This PR makes sender-address reads reactive in wallet-sensitive forms and adds regression tests for session changes. It covers disconnect/reconnect and account-switch flows to ensure validation and post-condition inputs always use the current wallet.

Alt short version:
Add tests and a sender refresh fix for wallet-sensitive forms so validation and contract calls stay aligned after wallet/session changes.

Closes #343 