### PR TITLE
Expose current fee rate read-only (#344)

### DIFF
--- a/contracts/tipstream-v2.clar
+++ b/contracts/tipstream-v2.clar
@@ -518,6 +518,10 @@
     (ok (var-get pending-owner))
 )
 
+(define-read-only (get-current-fee-basis-points)
+    (ok (var-get current-fee-basis-points))
+)
+
 (define-read-only (get-fee-for-amount (amount uint))
     (ok (calculate-fee amount))
 )

--- a/contracts/tipstream.clar
+++ b/contracts/tipstream.clar
@@ -510,6 +510,10 @@
     (ok (var-get pending-owner))
 )
 
+(define-read-only (get-current-fee-basis-points)
+    (ok (var-get current-fee-basis-points))
+)
+
 (define-read-only (get-fee-for-amount (amount uint))
     (ok (calculate-fee amount))
 )

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -41,3 +41,4 @@ export const FN_WHITELIST_TOKEN = 'whitelist-token';
 // Stats / read-only
 export const FN_GET_USER_STATS = 'get-user-stats';
 export const FN_GET_PLATFORM_STATS = 'get-platform-stats';
+export const FN_GET_CURRENT_FEE_BASIS_POINTS = 'get-current-fee-basis-points';

--- a/frontend/src/lib/admin-contract.js
+++ b/frontend/src/lib/admin-contract.js
@@ -7,7 +7,7 @@
  * enforce the 144-block timelock on all admin actions.
  */
 
-import { CONTRACT_ADDRESS, CONTRACT_NAME, STACKS_API_BASE } from '../config/contracts';
+import { CONTRACT_ADDRESS, CONTRACT_NAME, STACKS_API_BASE, FN_GET_CURRENT_FEE_BASIS_POINTS } from '../config/contracts';
 
 /**
  * Fetch the current block height from the Stacks API.
@@ -110,11 +110,7 @@ export async function fetchMultisig() {
  * @returns {Promise<number>} Current fee in basis points
  */
 export async function fetchCurrentFee() {
-    // Use get-fee-for-amount with a known amount to derive the rate
-    // 10000 microSTX -> fee = basis_points
-    const data = await callReadOnly('get-fee-for-amount', [
-        '0100000000000000000000000000002710', // u10000
-    ]);
+    const data = await callReadOnly(FN_GET_CURRENT_FEE_BASIS_POINTS);
     const result = parseClarityValue(data.result);
     return typeof result === 'number' ? result : 0;
 }

--- a/frontend/src/test/admin-contract.test.js
+++ b/frontend/src/test/admin-contract.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { parseClarityValue } from '../lib/admin-contract';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchCurrentFee, parseClarityValue } from '../lib/admin-contract';
 
 describe('parseClarityValue', () => {
     describe('null and invalid inputs', () => {
@@ -91,5 +91,32 @@ describe('parseClarityValue', () => {
         it('handles 0x prefix on none', () => {
             expect(parseClarityValue('0x09')).toBeNull();
         });
+    });
+});
+
+describe('fetchCurrentFee', () => {
+    beforeEach(() => {
+        global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('calls the current fee read-only and returns the decoded number', async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ result: '0x070100000000000000000000000000000032' }),
+        });
+
+        const fee = await fetchCurrentFee();
+
+        expect(fee).toBe(50);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        const [url, options] = global.fetch.mock.calls[0];
+        expect(url).toContain('/get-current-fee-basis-points');
+        expect(options.method).toBe('POST');
+        expect(JSON.parse(options.body)).toMatchObject({ arguments: [] });
     });
 });

--- a/tests/tipstream-v2.test.ts
+++ b/tests/tipstream-v2.test.ts
@@ -7,6 +7,12 @@ const wallet1 = accounts.get("wallet_1")!;
 const wallet2 = accounts.get("wallet_2")!;
 
 describe("TipStream V2 Contract Tests", () => {
+    it("exposes the current fee basis points via read-only", () => {
+        const { result } = simnet.callReadOnlyFn("tipstream-v2", "get-current-fee-basis-points", [], deployer);
+
+        expect(result).toBeOk(Cl.uint(50));
+    });
+
     it("reports the v2 contract version", () => {
         const { result } = simnet.callReadOnlyFn("tipstream-v2", "get-contract-version", [], deployer);
 

--- a/tests/tipstream.test.ts
+++ b/tests/tipstream.test.ts
@@ -123,6 +123,17 @@ describe("TipStream Contract Tests", () => {
         });
     });
 
+    it("exposes the current fee basis points via read-only", () => {
+        const { result } = simnet.callReadOnlyFn(
+            "tipstream",
+            "get-current-fee-basis-points",
+            [],
+            wallet1
+        );
+
+        expect(result).toBeOk(Cl.uint(50));
+    });
+
     it("fee calculation is correct", () => {
         const { result } = simnet.callReadOnlyFn(
             "tipstream",

--- a/tests/tipstream.test.ts
+++ b/tests/tipstream.test.ts
@@ -145,6 +145,22 @@ describe("TipStream Contract Tests", () => {
         expect(result).toBeOk(Cl.uint(5000));
     });
 
+    it("updates the current fee basis points when the owner changes it", () => {
+        const setFee = simnet.callPublicFn("tipstream", "set-fee-basis-points", [Cl.uint(75)], deployer);
+        expect(setFee.result).toBeOk(Cl.bool(true));
+
+        const { result } = simnet.callReadOnlyFn(
+            "tipstream",
+            "get-current-fee-basis-points",
+            [],
+            wallet1
+        );
+
+        expect(result).toBeOk(Cl.uint(75));
+
+        simnet.callPublicFn("tipstream", "set-fee-basis-points", [Cl.uint(50)], deployer);
+    });
+
     it("enforces minimum fee of 1 uSTX when raw calculation truncates to zero", () => {
         simnet.callPublicFn("tipstream", "set-fee-basis-points", [Cl.uint(1)], deployer);
 


### PR DESCRIPTION
## Summary
- Add a direct read-only contract function to fetch the current fee basis points.
- Update the frontend admin contract helper to call the new read-only endpoint directly.
- Add contract and frontend unit coverage for the new lookup.

## Testing
- npm test
- (frontend) npm test -- admin-contract.test.js
