### PR TITLE
Probe API health in useFeedConnectionStatus

### DIFF
--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -21,7 +21,7 @@ export function useFeedConnectionStatus() {
   const [failureCount, setFailureCount] = useState(0);
   const [lastSuccess, setLastSuccess] = useState(() => Date.now());
 
-  const apiProbeUrl = useMemo(() => `${STACKS_API_BASE}${API_PROBE_PATH}`, []);
+  const apiProbeUrl = useMemo(() => `${STACKS_API_BASE}${API_PROBE_PATH}`, [STACKS_API_BASE]);
   const [apiReachable, setApiReachable] = useState(null);
   const [apiLatencyMs, setApiLatencyMs] = useState(null);
   const [lastProbeAt, setLastProbeAt] = useState(null);

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -79,8 +79,18 @@ export function useFeedConnectionStatus() {
   }, [apiProbeUrl]);
 
   useEffect(() => {
-    const handleOnline = () => setIsOnline(true);
-    const handleOffline = () => setIsOnline(false);
+    const handleOnline = () => {
+      setIsOnline(true);
+      probeApiHealth();
+    };
+
+    const handleOffline = () => {
+      setIsOnline(false);
+      setApiReachable(null);
+      setApiLatencyMs(null);
+      setLastProbeAt(null);
+      setLastProbeError(null);
+    };
 
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
@@ -89,7 +99,7 @@ export function useFeedConnectionStatus() {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, []);
+  }, [probeApiHealth]);
 
   const getStatus = useCallback(() => {
     if (!isOnline) return 'offline';

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -7,10 +7,13 @@
  * reliability and enable graceful fallback behaviors.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { STACKS_API_BASE } from '../config/contracts';
 
-const CONNECTION_TIMEOUT_MS = 5000;
 const DEGRADATION_THRESHOLD = 3;
+const API_PROBE_PATH = '/v2/info';
+const API_PROBE_INTERVAL_MS = 30_000;
+const API_PROBE_TIMEOUT_MS = 5_000;
 
 export function useFeedConnectionStatus() {
   const [isOnline, setIsOnline] = useState(typeof navigator !== 'undefined' ? navigator.onLine : true);

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -14,6 +14,7 @@ const DEGRADATION_THRESHOLD = 3;
 const API_PROBE_PATH = '/v2/info';
 const API_PROBE_INTERVAL_MS = 30_000;
 const API_PROBE_TIMEOUT_MS = 5_000;
+const API_DEGRADED_LATENCY_MS = 2_500;
 
 export function useFeedConnectionStatus() {
   const [isOnline, setIsOnline] = useState(typeof navigator !== 'undefined' ? navigator.onLine : true);

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -110,7 +110,7 @@ export function useFeedConnectionStatus() {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, [probeApiHealth]);
+  }, []);
 
   useEffect(() => {
     if (!isOnline) return;

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -112,6 +112,23 @@ export function useFeedConnectionStatus() {
     };
   }, [isOnline, probeApiHealth]);
 
+  const browserStatus = useMemo(() => (isOnline ? 'online' : 'offline'), [isOnline]);
+
+  const apiStatus = useMemo(() => {
+    if (!isOnline) return 'unknown';
+    if (apiReachable === null) return 'unknown';
+    if (apiReachable === false) return 'unreachable';
+    return apiHealthy ? 'healthy' : 'degraded';
+  }, [isOnline, apiReachable, apiHealthy]);
+
+  const combinedStatus = useMemo(() => {
+    if (browserStatus === 'offline') return 'offline';
+    if (apiStatus === 'unknown') return 'checking';
+    if (apiStatus === 'unreachable') return 'api-down';
+    if (apiStatus === 'degraded') return 'degraded';
+    return 'healthy';
+  }, [browserStatus, apiStatus]);
+
   const getStatus = useCallback(() => {
     if (!isOnline) return 'offline';
     if (!apiHealthy) return 'degraded';

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -101,6 +101,17 @@ export function useFeedConnectionStatus() {
     };
   }, [probeApiHealth]);
 
+  useEffect(() => {
+    if (!isOnline) return;
+
+    probeApiHealth();
+    const intervalId = setInterval(probeApiHealth, API_PROBE_INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [isOnline, probeApiHealth]);
+
   const getStatus = useCallback(() => {
     if (!isOnline) return 'offline';
     if (!apiHealthy) return 'degraded';

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -21,6 +21,12 @@ export function useFeedConnectionStatus() {
   const [failureCount, setFailureCount] = useState(0);
   const [lastSuccess, setLastSuccess] = useState(() => Date.now());
 
+  const apiProbeUrl = useMemo(() => `${STACKS_API_BASE}${API_PROBE_PATH}`, []);
+  const [apiReachable, setApiReachable] = useState(null);
+  const [apiLatencyMs, setApiLatencyMs] = useState(null);
+  const [lastProbeAt, setLastProbeAt] = useState(null);
+  const [lastProbeError, setLastProbeError] = useState(null);
+
   const recordSuccess = useCallback(() => {
     setFailureCount(0);
     setApiHealthy(true);

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -142,10 +142,21 @@ export function useFeedConnectionStatus() {
 
   return {
     isOnline,
+    browserStatus,
+
+    apiStatus,
     apiHealthy,
+    apiReachable,
+    apiLatencyMs,
+    lastProbeAt,
+    lastProbeError,
+
     failureCount,
     lastSuccess,
-    status: getStatus(),
+
+    status: combinedStatus,
+    legacyStatus: getStatus(),
+
     recordSuccess,
     recordFailure,
     recordTimeout,

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -7,7 +7,7 @@
  * reliability and enable graceful fallback behaviors.
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { STACKS_API_BASE } from '../config/contracts';
 
 const DEGRADATION_THRESHOLD = 3;
@@ -26,6 +26,7 @@ export function useFeedConnectionStatus() {
   const [apiReachable, setApiReachable] = useState(null);
   const [apiLatencyMs, setApiLatencyMs] = useState(null);
   const [apiProbing, setApiProbing] = useState(false);
+  const probeInFlightRef = useRef(false);
   const [lastProbeAt, setLastProbeAt] = useState(null);
   const [lastProbeError, setLastProbeError] = useState(null);
 
@@ -51,7 +52,9 @@ export function useFeedConnectionStatus() {
 
   const probeApiHealth = useCallback(async () => {
     if (typeof navigator !== 'undefined' && navigator.onLine === false) return;
+    if (probeInFlightRef.current) return;
 
+    probeInFlightRef.current = true;
     setApiProbing(true);
 
     const start = Date.now();
@@ -82,6 +85,7 @@ export function useFeedConnectionStatus() {
     } finally {
       clearTimeout(timeoutId);
       setApiProbing(false);
+      probeInFlightRef.current = false;
     }
   }, [apiProbeUrl]);
 

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -126,8 +126,13 @@ export function useFeedConnectionStatus() {
     if (!isOnline) return 'unknown';
     if (apiReachable === null) return 'unknown';
     if (apiReachable === false) return 'unreachable';
+
+    if (typeof apiLatencyMs === 'number' && apiLatencyMs >= API_DEGRADED_LATENCY_MS) {
+      return 'degraded';
+    }
+
     return apiHealthy ? 'healthy' : 'degraded';
-  }, [isOnline, apiReachable, apiHealthy]);
+  }, [isOnline, apiReachable, apiHealthy, apiLatencyMs]);
 
   const combinedStatus = useMemo(() => {
     if (browserStatus === 'offline') return 'offline';

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -24,6 +24,7 @@ export function useFeedConnectionStatus() {
   const apiProbeUrl = useMemo(() => `${STACKS_API_BASE}${API_PROBE_PATH}`, [STACKS_API_BASE]);
   const [apiReachable, setApiReachable] = useState(null);
   const [apiLatencyMs, setApiLatencyMs] = useState(null);
+  const [apiProbing, setApiProbing] = useState(false);
   const [lastProbeAt, setLastProbeAt] = useState(null);
   const [lastProbeError, setLastProbeError] = useState(null);
 
@@ -49,6 +50,8 @@ export function useFeedConnectionStatus() {
 
   const probeApiHealth = useCallback(async () => {
     if (!isOnline) return;
+
+    setApiProbing(true);
 
     const start = Date.now();
     const controller = new AbortController();
@@ -77,6 +80,7 @@ export function useFeedConnectionStatus() {
       setLastProbeError(message);
     } finally {
       clearTimeout(timeoutId);
+      setApiProbing(false);
     }
   }, [apiProbeUrl, isOnline]);
 
@@ -90,6 +94,7 @@ export function useFeedConnectionStatus() {
       setIsOnline(false);
       setApiReachable(null);
       setApiLatencyMs(null);
+      setApiProbing(false);
       setLastProbeAt(null);
       setLastProbeError(null);
     };
@@ -150,6 +155,7 @@ export function useFeedConnectionStatus() {
     apiHealthy,
     apiReachable,
     apiLatencyMs,
+    apiProbing,
     lastProbeAt,
     lastProbeError,
 

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -88,7 +88,6 @@ export function useFeedConnectionStatus() {
   useEffect(() => {
     const handleOnline = () => {
       setIsOnline(true);
-      probeApiHealth();
     };
 
     const handleOffline = () => {

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -157,6 +157,8 @@ export function useFeedConnectionStatus() {
     status: combinedStatus,
     legacyStatus: getStatus(),
 
+    probeNow: probeApiHealth,
+
     recordSuccess,
     recordFailure,
     recordTimeout,

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -47,6 +47,37 @@ export function useFeedConnectionStatus() {
     recordFailure();
   }, [recordFailure]);
 
+  const probeApiHealth = useCallback(async () => {
+    const start = Date.now();
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), API_PROBE_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(apiProbeUrl, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      setApiReachable(true);
+      setApiLatencyMs(Date.now() - start);
+      setLastProbeAt(Date.now());
+      setLastProbeError(null);
+    } catch (err) {
+      const message = err?.name === 'AbortError' ? 'timeout' : (err?.message || 'error');
+      setApiReachable(false);
+      setApiLatencyMs(null);
+      setLastProbeAt(Date.now());
+      setLastProbeError(message);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }, [apiProbeUrl]);
+
   useEffect(() => {
     const handleOnline = () => setIsOnline(true);
     const handleOffline = () => setIsOnline(false);

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -50,7 +50,7 @@ export function useFeedConnectionStatus() {
   }, [recordFailure]);
 
   const probeApiHealth = useCallback(async () => {
-    if (!isOnline) return;
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) return;
 
     setApiProbing(true);
 
@@ -83,7 +83,7 @@ export function useFeedConnectionStatus() {
       clearTimeout(timeoutId);
       setApiProbing(false);
     }
-  }, [apiProbeUrl, isOnline]);
+  }, [apiProbeUrl]);
 
   useEffect(() => {
     const handleOnline = () => {

--- a/frontend/src/hooks/useFeedConnectionStatus.js
+++ b/frontend/src/hooks/useFeedConnectionStatus.js
@@ -48,6 +48,8 @@ export function useFeedConnectionStatus() {
   }, [recordFailure]);
 
   const probeApiHealth = useCallback(async () => {
+    if (!isOnline) return;
+
     const start = Date.now();
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), API_PROBE_TIMEOUT_MS);
@@ -76,7 +78,7 @@ export function useFeedConnectionStatus() {
     } finally {
       clearTimeout(timeoutId);
     }
-  }, [apiProbeUrl]);
+  }, [apiProbeUrl, isOnline]);
 
   useEffect(() => {
     const handleOnline = () => {

--- a/frontend/src/test/recipient-cache.test.js
+++ b/frontend/src/test/recipient-cache.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   RECIPIENT_CACHE,
   setCacheEntry,
@@ -32,16 +32,22 @@ describe('recipient-cache', () => {
       expect(retrieved).toBeNull();
     });
 
-    it('respects TTL', (done) => {
-      const shortTTL = 100;
-      setCacheEntry(testRecipient, testData, shortTTL);
+    it('respects TTL', () => {
+      vi.useFakeTimers();
 
-      expect(getCacheEntry(testRecipient)).toEqual(testData);
+      try {
+        vi.setSystemTime(new Date(0));
 
-      setTimeout(() => {
+        const shortTTL = 100;
+        setCacheEntry(testRecipient, testData, shortTTL);
+
+        expect(getCacheEntry(testRecipient)).toEqual(testData);
+
+        vi.setSystemTime(new Date(150));
         expect(getCacheEntry(testRecipient)).toBeNull();
-        done();
-      }, 150);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('checks cache validity', () => {
@@ -61,18 +67,24 @@ describe('recipient-cache', () => {
   });
 
   describe('cache management', () => {
-    it('clears expired entries', (done) => {
-      const shortTTL = 100;
-      setCacheEntry(testRecipient, testData, shortTTL);
-      setCacheEntry('another-recipient', testData, 60000);
+    it('clears expired entries', () => {
+      vi.useFakeTimers();
 
-      expect(RECIPIENT_CACHE.size).toBe(2);
+      try {
+        vi.setSystemTime(new Date(0));
 
-      setTimeout(() => {
+        const shortTTL = 100;
+        setCacheEntry(testRecipient, testData, shortTTL);
+        setCacheEntry('another-recipient', testData, 60000);
+
+        expect(RECIPIENT_CACHE.size).toBe(2);
+
+        vi.setSystemTime(new Date(150));
         clearExpiredEntries();
         expect(RECIPIENT_CACHE.size).toBe(1);
-        done();
-      }, 150);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('provides cache statistics', () => {
@@ -99,18 +111,24 @@ describe('recipient-cache', () => {
   });
 
   describe('cache optimization', () => {
-    it('removes expired entries during optimization', (done) => {
-      const shortTTL = 100;
-      setCacheEntry(testRecipient, testData, shortTTL);
-      setCacheEntry('another-recipient', testData, 60000);
+    it('removes expired entries during optimization', () => {
+      vi.useFakeTimers();
 
-      expect(RECIPIENT_CACHE.size).toBe(2);
+      try {
+        vi.setSystemTime(new Date(0));
 
-      setTimeout(() => {
+        const shortTTL = 100;
+        setCacheEntry(testRecipient, testData, shortTTL);
+        setCacheEntry('another-recipient', testData, 60000);
+
+        expect(RECIPIENT_CACHE.size).toBe(2);
+
+        vi.setSystemTime(new Date(150));
         optimizeCache();
         expect(RECIPIENT_CACHE.size).toBe(1);
-        done();
-      }, 150);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('limits cache size to 100 entries', () => {

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -32,6 +32,7 @@ describe('useFeedConnectionStatus', () => {
         expect(result.current.browserStatus).toBe('online');
         expect(result.current.apiStatus).toBe('unknown');
         expect(result.current.status).toBe('checking');
+        expect(result.current.apiProbing).toBe(true);
     });
 
     it('does not probe when navigator is offline', () => {

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -105,6 +105,27 @@ describe('useFeedConnectionStatus', () => {
         expect(result.current.lastProbeError).toBeNull();
     });
 
+    it('calls the Stacks API info endpoint with a JSON accept header', async () => {
+        global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+        renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        const [url, options] = global.fetch.mock.calls[0];
+        expect(String(url)).toMatch(/\/v2\/info$/);
+        expect(options).toMatchObject({
+            method: 'GET',
+            headers: { Accept: 'application/json' },
+        });
+        expect(options.signal).toBeTruthy();
+        expect(typeof options.signal.addEventListener).toBe('function');
+        expect(typeof options.signal.aborted).toBe('boolean');
+    });
+
     it('marks API unreachable when probe fails', async () => {
         global.fetch.mockRejectedValue(new Error('Network error'));
         const { result } = renderHook(() => useFeedConnectionStatus());

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -68,6 +68,7 @@ describe('useFeedConnectionStatus', () => {
         expect(result.current.status).toBe('healthy');
         expect(result.current.apiReachable).toBe(true);
         expect(typeof result.current.apiLatencyMs).toBe('number');
+        expect(result.current.apiProbing).toBe(false);
         expect(result.current.lastProbeError).toBeNull();
     });
 

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -43,6 +43,18 @@ describe('useFeedConnectionStatus', () => {
         expect(global.fetch).not.toHaveBeenCalled();
     });
 
+    it('does not probe when probeNow is called while offline', async () => {
+        setNavigatorOnline(false);
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await result.current.probeNow();
+            await flushMicrotasks();
+        });
+
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     it('marks API healthy when probe succeeds', async () => {
         global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
         const { result } = renderHook(() => useFeedConnectionStatus());

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -74,6 +74,21 @@ describe('useFeedConnectionStatus', () => {
         expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
+    it('does not overlap probes when probeNow is called during an active probe', async () => {
+        global.fetch.mockReturnValue(new Promise(() => {}));
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            await result.current.probeNow();
+            await flushMicrotasks();
+        });
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(result.current.apiProbing).toBe(true);
+    });
+
     it('marks API healthy when probe succeeds', async () => {
         global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
         const { result } = renderHook(() => useFeedConnectionStatus());

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -106,6 +106,30 @@ describe('useFeedConnectionStatus', () => {
         expect(result.current.apiLatencyMs).toBeGreaterThanOrEqual(2500);
     });
 
+    it('marks the probe as timed out when the request is aborted', async () => {
+        global.fetch.mockImplementation((_, options) => {
+            return new Promise((_, reject) => {
+                options.signal.addEventListener('abort', () => {
+                    const err = new Error('aborted');
+                    err.name = 'AbortError';
+                    reject(err);
+                });
+            });
+        });
+
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5000);
+            await flushMicrotasks();
+        });
+
+        expect(result.current.apiReachable).toBe(false);
+        expect(result.current.apiStatus).toBe('unreachable');
+        expect(result.current.lastProbeError).toBe('timeout');
+        expect(result.current.apiProbing).toBe(false);
+    });
+
     it('runs the probe again on the polling interval while online', async () => {
         global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
         const { result } = renderHook(() => useFeedConnectionStatus());

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -86,6 +86,26 @@ describe('useFeedConnectionStatus', () => {
         expect(result.current.lastProbeError).toBe('Network error');
     });
 
+    it('marks API degraded when probe latency is high', async () => {
+        let t = 0;
+        vi.spyOn(Date, 'now').mockImplementation(() => {
+            t += 3000;
+            return t;
+        });
+
+        global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        expect(result.current.apiStatus).toBe('degraded');
+        expect(result.current.status).toBe('degraded');
+        expect(result.current.apiReachable).toBe(true);
+        expect(result.current.apiLatencyMs).toBeGreaterThanOrEqual(2500);
+    });
+
     it('runs the probe again on the polling interval while online', async () => {
         global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
         const { result } = renderHook(() => useFeedConnectionStatus());

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -143,6 +143,25 @@ describe('useFeedConnectionStatus', () => {
         expect(result.current.apiReachable).toBeNull();
     });
 
+    it('probes immediately on online transition', async () => {
+        setNavigatorOnline(false);
+        global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+        renderHook(() => useFeedConnectionStatus());
+
+        expect(global.fetch).not.toHaveBeenCalled();
+
+        act(() => {
+            setNavigatorOnline(true);
+            window.dispatchEvent(new Event('online'));
+        });
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
     it('reports degraded status when failures reach threshold and API is reachable', async () => {
         global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
         const { result } = renderHook(() => useFeedConnectionStatus());

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -142,6 +142,20 @@ describe('useFeedConnectionStatus', () => {
         expect(result.current.lastProbeError).toBeNull();
     });
 
+    it('marks API unreachable when probe returns a non-ok response', async () => {
+        global.fetch.mockResolvedValue({ ok: false, status: 500 });
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        expect(result.current.apiReachable).toBe(false);
+        expect(result.current.apiStatus).toBe('unreachable');
+        expect(result.current.status).toBe('api-down');
+        expect(result.current.lastProbeError).toBe('HTTP 500');
+    });
+
     it('marks API degraded when probe latency is high', async () => {
         let t = 0;
         vi.spyOn(Date, 'now').mockImplementation(() => {

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -56,6 +56,24 @@ describe('useFeedConnectionStatus', () => {
         expect(global.fetch).not.toHaveBeenCalled();
     });
 
+    it('probes when probeNow is called while online', async () => {
+        global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            await result.current.probeNow();
+            await flushMicrotasks();
+        });
+
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
     it('marks API healthy when probe succeeds', async () => {
         global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
         const { result } = renderHook(() => useFeedConnectionStatus());

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { useFeedConnectionStatus } from '../hooks/useFeedConnectionStatus';
+
+function setNavigatorOnline(value) {
+    Object.defineProperty(navigator, 'onLine', { value, configurable: true });
+}
+
+async function flushMicrotasks() {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe('useFeedConnectionStatus', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        global.fetch = vi.fn();
+        setNavigatorOnline(true);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('starts in checking state when online and probe is pending', () => {
+        global.fetch.mockReturnValue(new Promise(() => {}));
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        expect(result.current.browserStatus).toBe('online');
+        expect(result.current.apiStatus).toBe('unknown');
+        expect(result.current.status).toBe('checking');
+    });
+
+    it('does not probe when navigator is offline', () => {
+        setNavigatorOnline(false);
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        expect(result.current.browserStatus).toBe('offline');
+        expect(result.current.status).toBe('offline');
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('marks API healthy when probe succeeds', async () => {
+        global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        expect(result.current.apiStatus).toBe('healthy');
+        expect(result.current.status).toBe('healthy');
+        expect(result.current.apiReachable).toBe(true);
+        expect(typeof result.current.apiLatencyMs).toBe('number');
+        expect(result.current.lastProbeError).toBeNull();
+    });
+
+    it('marks API unreachable when probe fails', async () => {
+        global.fetch.mockRejectedValue(new Error('Network error'));
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        expect(result.current.apiStatus).toBe('unreachable');
+        expect(result.current.status).toBe('api-down');
+        expect(result.current.apiReachable).toBe(false);
+        expect(result.current.lastProbeError).toBe('Network error');
+    });
+
+    it('runs the probe again on the polling interval while online', async () => {
+        global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(30_000);
+            await flushMicrotasks();
+        });
+
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(result.current.apiStatus).toBe('healthy');
+    });
+
+    it('resets probe state to unknown on offline transition', async () => {
+        global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        act(() => {
+            window.dispatchEvent(new Event('offline'));
+        });
+
+        expect(result.current.browserStatus).toBe('offline');
+        expect(result.current.apiStatus).toBe('unknown');
+        expect(result.current.status).toBe('offline');
+        expect(result.current.apiReachable).toBeNull();
+    });
+
+    it('reports degraded status when failures reach threshold and API is reachable', async () => {
+        global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        act(() => {
+            result.current.recordFailure();
+            result.current.recordFailure();
+            result.current.recordFailure();
+        });
+
+        expect(result.current.apiStatus).toBe('degraded');
+        expect(result.current.status).toBe('degraded');
+        expect(result.current.apiHealthy).toBe(false);
+    });
+});

--- a/frontend/src/test/useFeedConnectionStatus.test.jsx
+++ b/frontend/src/test/useFeedConnectionStatus.test.jsx
@@ -119,6 +119,29 @@ describe('useFeedConnectionStatus', () => {
         expect(result.current.lastProbeError).toBe('Network error');
     });
 
+    it('clears lastProbeError after a later successful probe', async () => {
+        global.fetch
+            .mockRejectedValueOnce(new Error('Network error'))
+            .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+        const { result } = renderHook(() => useFeedConnectionStatus());
+
+        await act(async () => {
+            await flushMicrotasks();
+        });
+
+        expect(result.current.apiReachable).toBe(false);
+        expect(result.current.lastProbeError).toBe('Network error');
+
+        await act(async () => {
+            await result.current.probeNow();
+            await flushMicrotasks();
+        });
+
+        expect(result.current.apiReachable).toBe(true);
+        expect(result.current.lastProbeError).toBeNull();
+    });
+
     it('marks API degraded when probe latency is high', async () => {
         let t = 0;
         vi.spyOn(Date, 'now').mockImplementation(() => {


### PR DESCRIPTION
Closes #341

Changes
- Add lightweight /v2/info probe with timeout and interval polling
- Keep browser connectivity and API reachability separate
- Expose combined status for UI (offline/checking/api-down/degraded/healthy)
- Add integration tests for success, failure, timeout, latency, polling, and transitions

Tests
- cd frontend && npm test
