### PR TITLE
Fix/balance hook cleanup

### DIFF
--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -87,7 +87,9 @@ export function useBalance(address) {
         retryCount.current = 0;
 
         const attempt = async () => {
-            if (abortControllerRef.current) abortControllerRef.current.abort();
+            if (abortControllerRef.current) {
+                abortControllerRef.current.abort();
+            }
             abortControllerRef.current = new AbortController();
 
             try {
@@ -120,7 +122,7 @@ export function useBalance(address) {
                     try {
                         await delay(RETRY_DELAY_MS, abortControllerRef.current.signal);
                     } catch (delayErr) {
-                        return; // Probably aborted
+                        return;
                     }
                     if (!isMounted.current) return;
                     return attempt();

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -39,12 +39,19 @@ function normalizeMicroStxBalance(rawBalance) {
  * @returns {{ balance: string|null, balanceStx: number|null, loading: boolean, error: string|null, lastFetched: number|null, refetch: () => Promise<void> }}
  */
 export function useBalance(address) {
+    const isMounted = useRef(true);
     const [balance, setBalance] = useState(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
     const [lastFetched, setLastFetched] = useState(null);
 
     const retryCount = useRef(0);
+
+    useEffect(() => {
+        return () => {
+            isMounted.current = false;
+        };
+    }, []);
 
     const fetchBalance = useCallback(async () => {
         if (!address) {

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -52,6 +52,8 @@ export function useBalance(address) {
     useEffect(() => {
         return () => {
             isMounted.current = false;
+            if (abortControllerRef.current) abortControllerRef.current.abort();
+            if (timeoutIdRef.current) clearTimeout(timeoutIdRef.current);
         };
     }, []);
 

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -68,14 +68,11 @@ export function useBalance(address) {
     const retryCount = useRef(0);
     /** @type {import('react').MutableRefObject<AbortController|null>} */
     const abortControllerRef = useRef(null);
-    /** @type {import('react').MutableRefObject<NodeJS.Timeout|null>} */
-    const timeoutIdRef = useRef(null);
 
     useEffect(() => {
         return () => {
             isMounted.current = false;
             if (abortControllerRef.current) abortControllerRef.current.abort();
-            if (timeoutIdRef.current) clearTimeout(timeoutIdRef.current);
         };
     }, []);
 

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -68,9 +68,13 @@ export function useBalance(address) {
         retryCount.current = 0;
 
         const attempt = async () => {
+            if (abortControllerRef.current) abortControllerRef.current.abort();
+            abortControllerRef.current = new AbortController();
+
             try {
                 const res = await fetch(
-                    `${STACKS_API_BASE}/extended/v1/address/${address}/stx`
+                    `${STACKS_API_BASE}/extended/v1/address/${address}/stx`,
+                    { signal: abortControllerRef.current.signal }
                 );
 
                 if (!res.ok) {

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -98,7 +98,10 @@ export function useBalance(address) {
 
                 if (retryCount.current < MAX_RETRIES) {
                     retryCount.current += 1;
-                    await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+                    await new Promise(r => {
+                        timeoutIdRef.current = setTimeout(r, RETRY_DELAY_MS);
+                    });
+                    timeoutIdRef.current = null;
                     return attempt();
                 }
                 console.error('Failed to fetch balance:', err.message);

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -117,7 +117,11 @@ export function useBalance(address) {
 
                 if (retryCount.current < MAX_RETRIES) {
                     retryCount.current += 1;
-                    await delay(RETRY_DELAY_MS, abortControllerRef.current.signal);
+                    try {
+                        await delay(RETRY_DELAY_MS, abortControllerRef.current.signal);
+                    } catch (delayErr) {
+                        return; // Probably aborted
+                    }
                     if (!isMounted.current) return;
                     return attempt();
                 }

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -56,7 +56,14 @@ function normalizeMicroStxBalance(rawBalance) {
  * error state. Call refetch() to manually retry after a failure.
  *
  * @param {string|null} address - Stacks principal to query. Pass null to skip.
- * @returns {{ balance: string|null, balanceStx: number|null, loading: boolean, error: string|null, lastFetched: number|null, refetch: () => Promise<void> }}
+ * @returns {{
+ *   balance: string|null,
+ *   balanceStx: number|null,
+ *   loading: boolean,
+ *   error: string|null,
+ *   lastFetched: number|null,
+ *   refetch: () => Promise<void>
+ * }} Hook state and refetch helper.
  */
 export function useBalance(address) {
     const isMounted = useRef(true);

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -46,7 +46,9 @@ export function useBalance(address) {
     const [lastFetched, setLastFetched] = useState(null);
 
     const retryCount = useRef(0);
+    /** @type {import('react').MutableRefObject<AbortController|null>} */
     const abortControllerRef = useRef(null);
+    /** @type {import('react').MutableRefObject<NodeJS.Timeout|null>} */
     const timeoutIdRef = useRef(null);
 
     useEffect(() => {

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -5,6 +5,26 @@ import { microToStx } from '../lib/balance-utils';
 const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 1500;
 
+/**
+ * Promise-based delay that can be cancelled via AbortSignal.
+ * @param {number} ms - Milliseconds to wait
+ * @param {AbortSignal} [signal] - Optional signal to cancel the delay
+ * @returns {Promise<void>}
+ */
+const delay = (ms, signal) => new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+        signal?.removeEventListener('abort', abortHandler);
+        resolve();
+    }, ms);
+
+    const abortHandler = () => {
+        clearTimeout(timeout);
+        reject(new Error('Aborted'));
+    };
+
+    signal?.addEventListener('abort', abortHandler, { once: true });
+});
+
 function normalizeMicroStxBalance(rawBalance) {
     if (typeof rawBalance === 'number') {
         if (!Number.isFinite(rawBalance) || !Number.isInteger(rawBalance) || rawBalance < 0) {

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -102,6 +102,7 @@ export function useBalance(address) {
                         timeoutIdRef.current = setTimeout(r, RETRY_DELAY_MS);
                     });
                     timeoutIdRef.current = null;
+                    if (!isMounted.current) return;
                     return attempt();
                 }
                 console.error('Failed to fetch balance:', err.message);

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -82,6 +82,7 @@ export function useBalance(address) {
                 }
 
                 const data = await res.json();
+                if (!isMounted.current) return;
 
                 const normalized = normalizeMicroStxBalance(data?.balance);
                 if (normalized === null) {
@@ -92,6 +93,9 @@ export function useBalance(address) {
                 setLastFetched(Date.now());
                 setLoading(false);
             } catch (err) {
+                if (err.name === 'AbortError') return;
+                if (!isMounted.current) return;
+
                 if (retryCount.current < MAX_RETRIES) {
                     retryCount.current += 1;
                     await new Promise(r => setTimeout(r, RETRY_DELAY_MS));

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -120,10 +120,7 @@ export function useBalance(address) {
 
                 if (retryCount.current < MAX_RETRIES) {
                     retryCount.current += 1;
-                    await new Promise(r => {
-                        timeoutIdRef.current = setTimeout(r, RETRY_DELAY_MS);
-                    });
-                    timeoutIdRef.current = null;
+                    await delay(RETRY_DELAY_MS, abortControllerRef.current.signal);
                     if (!isMounted.current) return;
                     return attempt();
                 }

--- a/frontend/src/hooks/useBalance.js
+++ b/frontend/src/hooks/useBalance.js
@@ -46,6 +46,8 @@ export function useBalance(address) {
     const [lastFetched, setLastFetched] = useState(null);
 
     const retryCount = useRef(0);
+    const abortControllerRef = useRef(null);
+    const timeoutIdRef = useRef(null);
 
     useEffect(() => {
         return () => {

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -234,4 +234,18 @@ describe('useBalance Hook', () => {
 
         expect(result.current.lastFetched).toBeGreaterThan(firstFetched);
     });
+
+    it('handles large balance strings', async () => {
+        const largeBalance = '1000000000000000000000000'; // Way beyond Number.MAX_SAFE_INTEGER
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ balance: largeBalance })
+        });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(result.current.balance).toBe(largeBalance));
+        // balanceStx might be Infinity or null depending on how microToStx handles it
+        // but the raw balance should be correct
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -272,4 +272,16 @@ describe('useBalance Hook', () => {
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
         expect(result.current.balance).toBe(null);
     });
+
+    it('handles empty response gracefully', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({})
+        });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        expect(result.current.balance).toBe(null);
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -104,4 +104,20 @@ describe('useBalance Hook', () => {
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
         expect(result.current.error).toContain('Unexpected balance format');
     });
+
+    it('resets balance when address becomes null', async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ balance: '1000' })
+        });
+
+        const { result, rerender } = renderHook(({ addr }) => useBalance(addr), {
+            initialProps: { addr: 'SP123' }
+        });
+
+        await waitFor(() => expect(result.current.balance).toBe('1000'));
+
+        rerender({ addr: null });
+        expect(result.current.balance).toBe(null);
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -248,4 +248,16 @@ describe('useBalance Hook', () => {
         // balanceStx might be Infinity or null depending on how microToStx handles it
         // but the raw balance should be correct
     });
+
+    it('handles negative balance from API as invalid', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ balance: -100 })
+        });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        expect(result.current.balance).toBe(null);
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -79,4 +79,17 @@ describe('useBalance Hook', () => {
         expect(result.current.error).toBe('API returned 404');
         expect(result.current.balance).toBe(null);
     });
+
+    it('handles malformed JSON response', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.reject(new Error('SyntaxError'))
+        });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        // It will retry twice then fail
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        expect(result.current.error).toBeDefined();
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -284,4 +284,23 @@ describe('useBalance Hook', () => {
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
         expect(result.current.balance).toBe(null);
     });
+
+    it('handles failure after success', async () => {
+        global.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ balance: '100' })
+            })
+            .mockRejectedValue(new Error('Later fail'));
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(result.current.balance).toBe('100'));
+
+        await act(async () => {
+            await result.current.refetch();
+        });
+
+        await waitFor(() => expect(result.current.error).toBeDefined());
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -67,7 +67,7 @@ describe('useBalance Hook', () => {
     });
 
     it('handles 404 response by setting error', async () => {
-        global.fetch.mockResolvedValueOnce({
+        global.fetch.mockResolvedValue({
             ok: false,
             status: 404,
             statusText: 'Not Found'
@@ -75,13 +75,13 @@ describe('useBalance Hook', () => {
 
         const { result } = renderHook(() => useBalance('SP123'));
 
-        await waitFor(() => expect(result.current.loading).toBe(false));
+        await waitFor(() => expect(result.current.loading).toBe(false), { timeout: 6000 });
         expect(result.current.error).toBe('API returned 404');
         expect(result.current.balance).toBe(null);
     });
 
     it('handles malformed JSON response', async () => {
-        global.fetch.mockResolvedValueOnce({
+        global.fetch.mockResolvedValue({
             ok: true,
             json: () => Promise.reject(new Error('SyntaxError'))
         });
@@ -89,12 +89,12 @@ describe('useBalance Hook', () => {
         const { result } = renderHook(() => useBalance('SP123'));
 
         // It will retry twice then fail
-        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 6000 });
         expect(result.current.error).toBeDefined();
     });
 
     it('handles invalid balance format from API', async () => {
-        global.fetch.mockResolvedValueOnce({
+        global.fetch.mockResolvedValue({
             ok: true,
             json: () => Promise.resolve({ balance: 'abc' })
         });
@@ -195,23 +195,25 @@ describe('useBalance Hook', () => {
 
     it('clears error on refetch', async () => {
         global.fetch
-            .mockRejectedValueOnce(new Error('First fail'))
-            .mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ balance: '100' })
-            });
+            .mockRejectedValue(new Error('Persistent fail')); // Fail all attempts
 
         const { result } = renderHook(() => useBalance('SP123'));
 
         // Wait for first one to fail all retries
-        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 6000 });
         expect(result.current.error).toBeDefined();
 
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ balance: '100' })
+        });
+
         await act(async () => {
-            result.current.refetch();
+            await result.current.refetch();
         });
 
         expect(result.current.error).toBe(null);
+        expect(result.current.balance).toBe('100');
     });
 
     it('updates lastFetched on success', async () => {
@@ -250,38 +252,38 @@ describe('useBalance Hook', () => {
     });
 
     it('handles negative balance from API as invalid', async () => {
-        global.fetch.mockResolvedValueOnce({
+        global.fetch.mockResolvedValue({
             ok: true,
             json: () => Promise.resolve({ balance: -100 })
         });
 
         const { result } = renderHook(() => useBalance('SP123'));
 
-        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 6000 });
         expect(result.current.balance).toBe(null);
     });
 
     it('handles decimal balance from API as invalid', async () => {
-        global.fetch.mockResolvedValueOnce({
+        global.fetch.mockResolvedValue({
             ok: true,
             json: () => Promise.resolve({ balance: 100.5 })
         });
 
         const { result } = renderHook(() => useBalance('SP123'));
 
-        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 6000 });
         expect(result.current.balance).toBe(null);
     });
 
     it('handles empty response gracefully', async () => {
-        global.fetch.mockResolvedValueOnce({
+        global.fetch.mockResolvedValue({
             ok: true,
             json: () => Promise.resolve({})
         });
 
         const { result } = renderHook(() => useBalance('SP123'));
 
-        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 6000 });
         expect(result.current.balance).toBe(null);
     });
 

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useBalance } from './useBalance';
+import { STACKS_API_BASE } from '../config/contracts';
+
+describe('useBalance Hook', () => {
+    beforeEach(() => {
+        global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('fetches balance successfully', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ balance: '1000000' })
+        });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.balance).toBe('1000000');
+        expect(result.current.balanceStx).toBe(1);
+        expect(result.current.error).toBe(null);
+    });
+
+    it('handles network errors with retries', async () => {
+        global.fetch
+            .mockRejectedValueOnce(new Error('Network failure'))
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ balance: '2000000' })
+            });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+        // It will automatically retry after 1500ms
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2), { timeout: 3000 });
+        await waitFor(() => expect(result.current.balance).toBe('2000000'));
+    });
+
+    it('cleans up resources and ignores updates on unmount', async () => {
+        global.fetch.mockImplementation(() => new Promise(() => {}));
+
+        const { unmount, result } = renderHook(() => useBalance('SP123'));
+        expect(result.current.loading).toBe(true);
+
+        unmount();
+    });
+
+    it('cancels retry timer on unmount', async () => {
+        global.fetch.mockRejectedValue(new Error('Persistent failure'));
+
+        const { unmount } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+        unmount();
+
+        // Wait a bit to ensure no second call is made
+        await new Promise(r => setTimeout(r, 2000));
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles 404 response by setting error', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            statusText: 'Not Found'
+        });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.error).toBe('API returned 404');
+        expect(result.current.balance).toBe(null);
+    });
+});

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -174,4 +174,22 @@ describe('useBalance Hook', () => {
         await refetchPromise;
         expect(result.current.balance).toBe('7000');
     });
+
+    it('manages loading state correctly', async () => {
+        let resolveFetch;
+        global.fetch.mockReturnValue(new Promise(resolve => { resolveFetch = resolve; }));
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        expect(result.current.loading).toBe(true);
+
+        await act(async () => {
+            resolveFetch({
+                ok: true,
+                json: () => Promise.resolve({ balance: '100' })
+            });
+        });
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -158,19 +158,20 @@ describe('useBalance Hook', () => {
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
 
         // Start second one
-        act(() => {
-            result.current.refetch();
+        let refetchPromise;
+        await act(async () => {
+            refetchPromise = result.current.refetch();
         });
 
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
 
-        // Resolve first one - should be ignored
+        // Resolve first one - should be ignored (it already threw AbortError internally)
         resolveFirst({
             ok: true,
             json: () => Promise.resolve({ balance: '1' })
         });
 
-        await waitFor(() => expect(result.current.balance).toBe('7000'));
-        expect(result.current.balance).not.toBe('1');
+        await refetchPromise;
+        expect(result.current.balance).toBe('7000');
     });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -213,4 +213,25 @@ describe('useBalance Hook', () => {
 
         expect(result.current.error).toBe(null);
     });
+
+    it('updates lastFetched on success', async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ balance: '100' })
+        });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(result.current.balance).toBe('100'));
+        const firstFetched = result.current.lastFetched;
+        expect(firstFetched).toBeGreaterThan(0);
+
+        await new Promise(r => setTimeout(r, 10));
+
+        await act(async () => {
+            await result.current.refetch();
+        });
+
+        expect(result.current.lastFetched).toBeGreaterThan(firstFetched);
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -260,4 +260,16 @@ describe('useBalance Hook', () => {
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
         expect(result.current.balance).toBe(null);
     });
+
+    it('handles decimal balance from API as invalid', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ balance: 100.5 })
+        });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        expect(result.current.balance).toBe(null);
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -92,4 +92,16 @@ describe('useBalance Hook', () => {
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
         expect(result.current.error).toBeDefined();
     });
+
+    it('handles invalid balance format from API', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ balance: 'abc' })
+        });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        expect(result.current.error).toContain('Unexpected balance format');
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -140,4 +140,37 @@ describe('useBalance Hook', () => {
 
         expect(result.current.balance).toBe('6000');
     });
+
+    it('refetch cancels in-flight request', async () => {
+        let resolveFirst;
+        const firstPromise = new Promise(resolve => { resolveFirst = resolve; });
+        
+        global.fetch
+            .mockReturnValueOnce(firstPromise)
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ balance: '7000' })
+            });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        // First one is in flight
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+        // Start second one
+        act(() => {
+            result.current.refetch();
+        });
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+
+        // Resolve first one - should be ignored
+        resolveFirst({
+            ok: true,
+            json: () => Promise.resolve({ balance: '1' })
+        });
+
+        await waitFor(() => expect(result.current.balance).toBe('7000'));
+        expect(result.current.balance).not.toBe('1');
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -192,4 +192,25 @@ describe('useBalance Hook', () => {
 
         await waitFor(() => expect(result.current.loading).toBe(false));
     });
+
+    it('clears error on refetch', async () => {
+        global.fetch
+            .mockRejectedValueOnce(new Error('First fail'))
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ balance: '100' })
+            });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        // Wait for first one to fail all retries
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3), { timeout: 5000 });
+        expect(result.current.error).toBeDefined();
+
+        await act(async () => {
+            result.current.refetch();
+        });
+
+        expect(result.current.error).toBe(null);
+    });
 });

--- a/frontend/src/hooks/useBalance.test.js
+++ b/frontend/src/hooks/useBalance.test.js
@@ -120,4 +120,24 @@ describe('useBalance Hook', () => {
         rerender({ addr: null });
         expect(result.current.balance).toBe(null);
     });
+
+    it('allows manual refetch', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ balance: '5000' })
+        }).mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ balance: '6000' })
+        });
+
+        const { result } = renderHook(() => useBalance('SP123'));
+
+        await waitFor(() => expect(result.current.balance).toBe('5000'));
+
+        await act(async () => {
+            await result.current.refetch();
+        });
+
+        expect(result.current.balance).toBe('6000');
+    });
 });


### PR DESCRIPTION
Changes Implemented:
Component Lifecycle Tracking: Added an isMounted ref to the useBalance hook to ensure state updates only occur if the component is still active.
Request Cancellation: Integrated AbortController into the fetch logic. Pending requests are now aborted immediately on hook unmount or when a new fetch (or manual refetch) is initiated.
Cancelable Retry Delay: Replaced the standard setTimeout promise with a custom delay utility that accepts an AbortSignal. This allows the hook to immediately stop waiting for a retry delay if the component unmounts.
Resource Cleanup: Updated the useEffect cleanup function to trigger both the AbortController and the cancellation of any active retry timers.
Comprehensive Testing: Created a new test suite useBalance.test.js with 18 test cases, including specific tests for:
Successful balance retrieval and normalization.
Automatic retries on network or transient failures.
Cancellation of in-flight requests and retry timers on unmount.
Prevention of state updates after hook disposal.
Manual refetch behavior and its interaction with existing in-flight requests.
Technical Details:
Branch: fix/balance-hook-cleanup
Commits: 30 granular, professional commits.
Tests: 18 passing tests in src/hooks/useBalance.test.js.

Closes #334 